### PR TITLE
feat(shell): add claude-glm failover for Z.ai GLM 5.1

### DIFF
--- a/modules/home/shell/zsh.nix
+++ b/modules/home/shell/zsh.nix
@@ -145,6 +145,32 @@ in
           local name="''${1:-screenshot}"
           agent-browser screenshot "./$name-$(date +%Y%m%d-%H%M%S).png"
         }
+
+        # ========================================
+        # Claude Code failover (GLM 5.1 via Z.ai)
+        # ========================================
+
+        # Launch Claude Code routed through Z.ai's GLM 5.1 API
+        # Usage: claude-glm [args...] (same args as claude)
+        function claude-glm() {
+          local zai_key
+          zai_key=$(esc run told/app/local -- printenv ZAI_API_KEY 2>/dev/null)
+          if [[ -z "$zai_key" ]]; then
+            echo "ERROR: ZAI_API_KEY not found in Pulumi ESC (told/app/local)." >&2
+            echo "  1. Check AWS SM: aws secretsmanager describe-secret --secret-id told/vendor/zai/api-key --region us-east-1" >&2
+            echo "  2. Sync ESC:     esc env edit told/app/base -f ~/src/told/infra/esc/base.yaml" >&2
+            return 1
+          fi
+          echo "→ Claude Code → GLM 5.1 via api.z.ai" >&2
+          ANTHROPIC_AUTH_TOKEN="$zai_key" \
+          ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic" \
+          ANTHROPIC_MODEL="glm-5.1" \
+          ANTHROPIC_DEFAULT_OPUS_MODEL="glm-5.1" \
+          ANTHROPIC_DEFAULT_SONNET_MODEL="glm-5.1" \
+          ANTHROPIC_DEFAULT_HAIKU_MODEL="glm-4.5-air" \
+          API_TIMEOUT_MS="3000000" \
+          claude "$@"
+        }
       '';
 
       history = {

--- a/modules/home/shell/zsh.nix
+++ b/modules/home/shell/zsh.nix
@@ -154,7 +154,7 @@ in
         # Usage: claude-glm [args...] (same args as claude)
         function claude-glm() {
           local zai_key
-          zai_key=$(esc run told/app/local -- printenv ZAI_API_KEY 2>/dev/null)
+          zai_key=$(esc open told/app/local --format shell 2>/dev/null | command grep '^export ZAI_API_KEY=' | sed 's/^export ZAI_API_KEY="//' | sed 's/"$//')
           if [[ -z "$zai_key" ]]; then
             echo "ERROR: ZAI_API_KEY not found in Pulumi ESC (told/app/local)." >&2
             echo "  1. Check AWS SM: aws secretsmanager describe-secret --secret-id told/vendor/zai/api-key --region us-east-1" >&2
@@ -162,7 +162,7 @@ in
             return 1
           fi
           echo "→ Claude Code → GLM 5.1 via api.z.ai" >&2
-          ANTHROPIC_AUTH_TOKEN="$zai_key" \
+          ANTHROPIC_API_KEY="$zai_key" \
           ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic" \
           ANTHROPIC_MODEL="glm-5.1" \
           ANTHROPIC_DEFAULT_OPUS_MODEL="glm-5.1" \


### PR DESCRIPTION
## Summary

- Adds `claude-glm` shell function that routes Claude Code through Z.ai's Anthropic-compatible API (GLM 5.1) as failover when Anthropic is down
- API key stored in AWS Secrets Manager (`told/vendor/zai/api-key`), referenced via Pulumi ESC (`told/app/base`)
- Env-var-only approach — no `settings.json` modifications, `claude` command unaffected

## Infrastructure changes (outside this repo)

- AWS SM secret: `told/vendor/zai/api-key` created
- ESC `told/app/base`: added `zaiApiKey` to vendorSecrets, `ZAI_API_KEY` env var

## Test plan

- [ ] Open new terminal, run `type claude-glm`
- [ ] Run `claude-glm --version`
- [ ] Run `claude --version` (regression check)
- [ ] Launch `claude-glm` interactively, run `/status` to verify GLM 5.1 model
- [ ] Verify CLAUDE.md and skills load correctly under GLM 5.1

Resolves TOLD-1592