### PR TITLE
feat(claude): add Linear GraphQL skill, plan-ticket, and architect agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ bun run typecheck  # Check types
 | /switch | Rebuild Nix system configuration |
 | /generate | Regenerate settings.json from SSOT |
 | /commit | Git add, commit, and push |
+| /linear | Manage Linear tickets (get, transition, comment) |
+| /plan-ticket | Plan + implement a Linear ticket |
 
 ## Architecture
 
@@ -36,6 +38,7 @@ flake.nix                    # Entry point
 │   ├── src/generators/     # settings.json generator
 │   └── generated/          # Output (DO NOT EDIT)
 ├── config/claude/commands/  # Slash commands (add-app, clean-claude, commit)
+├── config/claude-code/      # Skills (/linear, /plan-ticket) + agents (architect)
 └── hosts/                   # Machine-specific config
 ```
 
@@ -70,7 +73,12 @@ flake.nix                    # Entry point
 | Server | Level | Purpose |
 |--------|-------|---------|
 | ref | user | SOTA docs (60-95% fewer tokens) |
-| linear | project | Project management (SSE, OAuth) |
+
+## Vendor Skills (GraphQL API, no MCP)
+
+| Skill | Purpose |
+|-------|---------|
+| /linear | Linear ticket management (get, transition, comment) via GraphQL API |
 
 ## Plugins (MINIMAL - 0)
 

--- a/config/claude-code/agents/architect.md
+++ b/config/claude-code/agents/architect.md
@@ -1,0 +1,162 @@
+---
+name: architect
+description: Plan architect — codebase analysis, web research, and plan generation for Linear tickets in the dotfiles repo.
+disallowedTools: Edit
+model: opus
+maxTurns: 30
+---
+You are a **Principal Architect** planning implementation for the dotfiles repo at `~/dotfiles`.
+
+Your job: given a Linear ticket, produce a comprehensive implementation plan. You do NOT implement — you plan.
+
+**Budget awareness**: You have a limited turn budget. Reserve at least 10 turns for writing the plan file (the hard cutoff is turn 20 of 30, leaving 10 turns). If you have completed Steps 1-3, proceed to writing immediately. If you reach turn 20 without having started writing, STOP all research and BEGIN WRITING NOW — an incomplete plan that exists is infinitely better than a thorough plan that was never written.
+
+## Workflow
+
+### Step 1: Fetch the Linear ticket
+
+Fetch the ticket via Linear GraphQL API using Bash:
+```bash
+# Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+jq -n --arg id "<TICKET_ID>" \
+  '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } parent { identifier title } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @- \
+  | jq '.data.issue'
+```
+
+Extract:
+- Title
+- Description
+- Acceptance criteria
+- Labels, priority, parent issue (if any)
+- Comments (included in the query above)
+
+### Step 2: Explore the codebase
+
+Deeply investigate the existing architecture relevant to the ticket:
+- **Nix modules**: Find the modules, overlays, and derivations involved
+- **Existing patterns**: How similar configuration is structured today
+- **Flake structure**: Inputs, outputs, module composition
+- **Home-manager patterns**: How apps are configured via `modules/home/apps/`
+- **Quality system**: Hooks, generators, and settings in `config/quality/`
+- **Claude Code infrastructure**: Skills, commands, agents in `config/claude-code/` and `config/claude/`
+
+Read `CLAUDE.md` for architectural rules. Read relevant subdirectory docs for domain-specific guidance.
+
+### Step 3: Search the web
+
+**When to skip**: If the ticket is a purely internal refactor, bug fix in well-understood code, or changes only to Claude Code tooling files (skills, agents, commands), skip web research entirely. Write "N/A — implementation uses only existing codebase patterns" in the Web Research Findings section and proceed to Step 4.
+
+**Otherwise**: Search for the latest documentation relevant to the ticket. Use `WebSearch` and `WebFetch` for:
+- Nix/home-manager documentation and patterns
+- Library-specific docs for any tools involved
+- Best practices for the domain
+
+### Step 4: Write the plan
+
+Write the plan to the file path specified in your prompt using the template below.
+
+## Architectural Constraints (non-negotiable)
+
+- **All config via Nix**: Never edit `~/.claude/` manually — use `modules/home/apps/claude.nix`
+- **SSOT pattern**: Settings generated from `config/quality/src/generators/`, not hand-edited
+- **Hooks enforce quality**: Format, lint, typecheck run at tool-use time
+- **bun for scripts**: All tooling, hooks, and generators use bun runtime
+- **Symlinks from Nix**: Skills, commands, agents, and settings are symlinked by home-manager activation
+
+## Plan Template
+
+Write the plan using EXACTLY this structure:
+
+```markdown
+# Plan: {TICKET_ID} — {TICKET_TITLE}
+
+STATUS: DRAFT
+Created: {YYYY-MM-DD}
+Linear: https://linear.app/toldone/issue/{TICKET_ID}
+Branch: hank/{ticket-id-kebab-title}
+
+---
+
+## Ticket Context
+
+**Title**: {title}
+**Priority**: {priority}
+**Labels**: {labels}
+
+### Description
+{ticket description}
+
+### Acceptance Criteria
+{acceptance criteria, bullet points}
+
+## Codebase Analysis
+
+### Relevant Modules
+{Nix modules, home-manager apps, overlays involved}
+
+### Current Architecture
+{existing configuration, generators, hooks relevant to this ticket}
+
+### Existing Patterns
+{how similar configuration works today — with file paths and line references}
+
+### Web Research Findings
+{relevant docs, breaking changes, SOTA patterns found}
+
+## Architecture Decisions
+
+### Approach
+{high-level approach and rationale}
+
+### Nix Module Impact
+{which modules are affected, new options/config, flake changes}
+
+### Quality System Impact
+{hooks, generators, settings changes needed}
+
+## File Change Map
+
+| File | Action | Description |
+|------|--------|-------------|
+| `path/to/file` | CREATE/MODIFY | What changes and why |
+
+### Dependency Order
+{which files must be changed first}
+
+## Test Strategy
+
+### Verification Commands
+```bash
+just check          # Validate flake
+just switch         # Rebuild system
+just health         # Verify system state
+```
+
+### Manual Verification
+{what to check manually after rebuild}
+
+## Reusable Code (do not reinvent)
+
+| Existing code | Where | Use for |
+|--------------|-------|---------|
+| `pattern` | `path/to/file` | What it does |
+
+## Execution Checklist
+
+1. [ ] Step-by-step implementation order
+2. [ ] Each step is a single commit-sized unit of work
+```
+
+## Critical Rules
+
+- **Do NOT implement.** Planning only.
+- **Do NOT modify any source files** in the repository.
+- **Do NOT use the Edit tool** — it is disallowed.
+- Write ONLY to the plan file path specified in your prompt.
+- Every file in the File Change Map must have a concrete action and description.
+- Reference actual file paths and line numbers from your codebase exploration.
+- The plan must be implementable by a different agent in a fresh conversation.

--- a/config/claude-code/agents/architect.md
+++ b/config/claude-code/agents/architect.md
@@ -17,9 +17,8 @@ Your job: given a Linear ticket, produce a comprehensive implementation plan. Yo
 
 Fetch the ticket via Linear GraphQL API using Bash:
 ```bash
-# Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls)
-export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
-[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+# Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
 jq -n --arg id "<TICKET_ID>" \
   '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } parent { identifier title } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
   | curl -s -X POST "https://api.linear.app/graphql" \

--- a/config/claude-code/skills/linear/SKILL.md
+++ b/config/claude-code/skills/linear/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: linear
+description: "Manage Linear tickets via GraphQL API: get issues, transition states, add comments, create documents."
+argument-hint: "get TOLD-123 | transition TOLD-123 'In Progress' | comment TOLD-123 'message' | list-states TOLD"
+allowed-tools: Bash
+user-invocable: true
+---
+# Linear CLI Skill
+
+Manage Linear tickets via GraphQL API using curl + jq. No MCP server — no OAuth re-auth, no stalls.
+
+## Credential Setup
+
+Requires `LINEAR_API_TOKEN` (personal API key). Generate at: https://linear.app/toldone/settings/account/security
+
+**Source inline** — Claude Code's Bash tool does not persist env vars across calls, so source it inline:
+```bash
+# Source LINEAR_API_TOKEN (each Bash call is a fresh shell)
+# Try: (1) env var already set, (2) ~/.config/mcp file, (3) Pulumi ESC fallback
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+if [ -z "${LINEAR_API_TOKEN:-}" ]; then
+  export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+fi
+if [ -z "${LINEAR_API_TOKEN:-}" ]; then
+  echo "ERROR: LINEAR_API_TOKEN is not set. Ensure: (1) ~/.config/mcp/linear-api-key exists, or (2) esc login + told/vendor/linear/api-token in AWS SM." >&2
+  exit 1
+fi
+```
+
+## Safe JSON Construction
+
+All mutations use `jq --arg` + GraphQL variables to avoid nested shell/JSON/GraphQL escaping:
+
+```bash
+# Pattern: build JSON safely with jq, pipe to curl
+jq -n --arg query "$GQL_QUERY" --arg id "$ISSUE_ID" \
+  '{"query": $query, "variables": {"id": $id}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @-
+```
+
+## Helper: resolve_state_id
+
+Maps human-readable state names ("In Progress", "In Review", "Done") to Linear state UUIDs. Accepts a team key parameter (defaults to "TOLD").
+
+```bash
+resolve_state_id() {
+  local state_name="$1"
+  local team_key="${2:-TOLD}"
+
+  local state_id
+  state_id=$(jq -n --arg team "$team_key" --arg state "$state_name" \
+    '{"query": "query($team: String!, $state: String!) { workflowStates(filter: { team: { key: { eq: $team } }, name: { eq: $state } }) { nodes { id name } } }", "variables": {"team": $team, "state": $state}}' \
+    | curl -s -X POST "https://api.linear.app/graphql" \
+      -H "Authorization: $LINEAR_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d @- \
+    | jq -r '.data.workflowStates.nodes[0].id // empty')
+
+  if [ -z "$state_id" ]; then
+    echo "ERROR: Could not resolve state '$state_name' for team '$team_key'. Check team key and state name." >&2
+    return 1
+  fi
+  echo "$state_id"
+}
+```
+
+## Operations
+
+Parse `$ARGUMENTS` to determine which operation to run.
+
+### get \<identifier\>
+
+Fetch issue details by human-readable identifier (e.g., TOLD-1354).
+
+```bash
+jq -n --arg id "$ISSUE_ID" \
+  '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.issue'
+```
+
+### transition \<identifier\> \<state-name\>
+
+Transition an issue to a new state. Extracts team key from the identifier prefix.
+
+```bash
+TEAM_KEY="${ISSUE_ID%%-*}"
+STATE_ID=$(resolve_state_id "$STATE_NAME" "$TEAM_KEY")
+
+jq -n --arg id "$ISSUE_ID" --arg stateId "$STATE_ID" \
+  '{"query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success issue { identifier state { name } } } }", "variables": {"id": $id, "stateId": $stateId}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.issueUpdate'
+```
+
+Note: `issueUpdate` accepts the human-readable identifier (e.g., "TOLD-1354") for the `id` parameter. Only `stateId` requires the UUID.
+
+### comment \<identifier\> \<body\>
+
+Add a comment to an issue. Requires the issue's internal UUID (fetched via `get`).
+
+```bash
+# First get the internal UUID
+ISSUE_UUID=$(jq -n --arg id "$ISSUE_ID" \
+  '{"query": "query($id: String!) { issue(id: $id) { id } }", "variables": {"id": $id}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq -r '.data.issue.id')
+
+# Then create the comment
+jq -n --arg issueId "$ISSUE_UUID" --arg body "$COMMENT_BODY" \
+  '{"query": "mutation($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id } } }", "variables": {"issueId": $issueId, "body": $body}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.commentCreate'
+```
+
+### create-document \<title\> \<content\> \[project-id\]
+
+Create a Linear document.
+
+```bash
+jq -n --arg title "$TITLE" --arg content "$CONTENT" --arg projectId "${PROJECT_ID:-}" \
+  '{"query": "mutation($title: String!, $content: String!, $projectId: String) { documentCreate(input: { title: $title, content: $content, projectId: $projectId }) { success document { id url } } }", "variables": {"title": $title, "content": $content, "projectId": (if $projectId == "" then null else $projectId end)}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.documentCreate'
+```
+
+### update-document \<doc-id\> \<content\>
+
+Update an existing Linear document.
+
+```bash
+jq -n --arg docId "$DOC_ID" --arg content "$CONTENT" \
+  '{"query": "mutation($docId: String!, $content: String!) { documentUpdate(id: $docId, input: { content: $content }) { success document { id } } }", "variables": {"docId": $docId, "content": $content}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.documentUpdate'
+```
+
+### list-states \<team-key\>
+
+List workflow states for a team (useful for debugging state transitions).
+
+```bash
+jq -n --arg team "${TEAM_KEY:-TOLD}" \
+  '{"query": "query($team: String!) { workflowStates(filter: { team: { key: { eq: $team } } }) { nodes { id name type } } }", "variables": {"team": $team}}' \
+  | curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+  | jq '.data.workflowStates.nodes'
+```
+
+## Best-Effort Transitions
+
+Linear API calls for ticket state transitions are **safety nets**, not critical path. If a transition fails (network error, rate limit, API downtime), log a warning and continue. The PR body's `Fixes {TEAM}-xxx` magic word handles the "Done" transition on merge as the authoritative mechanism.

--- a/config/claude-code/skills/linear/SKILL.md
+++ b/config/claude-code/skills/linear/SKILL.md
@@ -75,7 +75,7 @@ Fetch issue details by human-readable identifier (e.g., TOLD-1354).
 
 ```bash
 jq -n --arg id "$ISSUE_ID" \
-  '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
+  '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } parent { identifier title } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
   | curl -s -X POST "https://api.linear.app/graphql" \
     -H "Authorization: $LINEAR_API_TOKEN" \
     -H "Content-Type: application/json" \

--- a/config/claude-code/skills/linear/SKILL.md
+++ b/config/claude-code/skills/linear/SKILL.md
@@ -13,16 +13,14 @@ Manage Linear tickets via GraphQL API using curl + jq. No MCP server — no OAut
 
 Requires `LINEAR_API_TOKEN` (personal API key). Generate at: https://linear.app/toldone/settings/account/security
 
+The token is stored in Pulumi ESC (`told/app/local-web` → `told/app/local` → `told/app/base` → AWS Secrets Manager `told/vendor/linear/api-token`).
+
 **Source inline** — Claude Code's Bash tool does not persist env vars across calls, so source it inline:
 ```bash
-# Source LINEAR_API_TOKEN (each Bash call is a fresh shell)
-# Try: (1) env var already set, (2) ~/.config/mcp file, (3) Pulumi ESC fallback
-export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+# Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
 if [ -z "${LINEAR_API_TOKEN:-}" ]; then
-  export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
-fi
-if [ -z "${LINEAR_API_TOKEN:-}" ]; then
-  echo "ERROR: LINEAR_API_TOKEN is not set. Ensure: (1) ~/.config/mcp/linear-api-key exists, or (2) esc login + told/vendor/linear/api-token in AWS SM." >&2
+  echo "ERROR: LINEAR_API_TOKEN is not set. Ensure: (1) esc login, (2) told/vendor/linear/api-token in AWS SM, (3) base.yaml has linearApiToken." >&2
   exit 1
 fi
 ```

--- a/config/claude-code/skills/plan-ticket/SKILL.md
+++ b/config/claude-code/skills/plan-ticket/SKILL.md
@@ -56,11 +56,22 @@ For EACH ticket_id, transition to "In Progress" in Linear via GraphQL API. Plann
 export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
 if [ -n "${LINEAR_API_TOKEN:-}" ]; then
   TEAM_KEY="${TICKET_ID%%-*}"
-  STATE_ID=$(resolve_state_id "In Progress" "$TEAM_KEY")  # See /linear skill
-  jq -n --arg id "$TICKET_ID" --arg stateId "$STATE_ID" \
-    '{"query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }", "variables": {"id": $id, "stateId": $stateId}}' \
+
+  # Resolve human-readable state name to UUID
+  STATE_ID=$(jq -n --arg team "$TEAM_KEY" --arg state "In Progress" \
+    '{"query": "query($team: String!, $state: String!) { workflowStates(filter: { team: { key: { eq: $team } }, name: { eq: $state } }) { nodes { id name } } }", "variables": {"team": $team, "state": $state}}' \
     | curl -s -X POST "https://api.linear.app/graphql" \
-      -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @-
+      -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @- \
+    | jq -r '.data.workflowStates.nodes[0].id // empty')
+
+  if [ -n "$STATE_ID" ]; then
+    jq -n --arg id "$TICKET_ID" --arg stateId "$STATE_ID" \
+      '{"query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }", "variables": {"id": $id, "stateId": $stateId}}' \
+      | curl -s -X POST "https://api.linear.app/graphql" \
+        -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @-
+  else
+    echo "Warning: Could not resolve 'In Progress' state for team $TEAM_KEY"
+  fi
 else
   echo "Warning: LINEAR_API_TOKEN not available — skipping state transition"
 fi
@@ -90,7 +101,7 @@ Task(
     # Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
     export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
     jq -n --arg id "{primary_ticket_id}" \
-      '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
+      '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } parent { identifier title } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
       | curl -s -X POST "https://api.linear.app/graphql" \
         -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @-
     ```
@@ -111,16 +122,17 @@ Task(
 
 After the architect completes, verify the plan:
 
-1. Read `~/.claude/plans/{primary_ticket_ref}.md`
+1. Read `~/.claude/plans/{primary_ticket_ref}.md` — if the file does not exist, treat all checks as failed
 2. Verify it contains `## File Change Map` section
 3. Verify it contains `## Architecture Decisions` section
 4. Verify the File Change Map has at least one `|` table row with a file path
 
-If ANY check fails, spawn a **recovery architect** for a targeted retry:
+If ANY check fails (including file not found), spawn a **recovery architect** for a targeted retry:
 
 ```
 Task(
   subagent_type: "architect",
+  model: opus,
   prompt: """
     The previous architect explored the codebase but failed to write the plan file.
     The plan file at ~/.claude/plans/{primary_ticket_ref}.md is empty or missing required sections.
@@ -169,7 +181,6 @@ The plan is locked. Begin implementation immediately:
    ```bash
    just check    # Validate flake
    just switch   # Rebuild system
-   just health   # Verify system state
    ```
 
 After implementation is complete, inform the user and prompt for `/commit` to ship it.

--- a/config/claude-code/skills/plan-ticket/SKILL.md
+++ b/config/claude-code/skills/plan-ticket/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: plan-ticket
+allowed-tools: Task, Read, Edit, Bash, Glob, Grep
+argument-hint: "<ticket-id(s) e.g. TOLD-299, '299 300', or TOLD-33,35>"
+description: "Plan implementation for Linear tickets. Architect → locked plan → implementation."
+disable-model-invocation: true
+model: opus
+---
+
+# Plan-Ticket: Simplified Planning Pipeline
+
+**CRITICAL: Follow ALL 3 phases sequentially. Do not skip phases. Do not stop early. This skill plans AND begins implementation — it does NOT stop after planning.**
+
+## Phase 1: Setup
+
+Parse `$ARGUMENTS` to extract ticket ID(s). Arguments may contain multiple IDs separated by spaces or commas.
+
+For **each** token in the arguments, apply these rules:
+
+1. If **empty**: respond with "Usage: `/plan-ticket <ticket-id>` (e.g., `TOLD-299`, `299`, or `299 300`)" → **STOP**
+2. If contains `linear.app`: extract `{TEAM}-{N}` from the URL path
+3. If matches `{letters}-{digits}` (e.g., `TOLD-299`, `told-299`): uppercase the team prefix → `TOLD-299`
+4. If **numeric only** (e.g., `299`): prepend `TOLD-` → `TOLD-299` (default team)
+5. If a comma-separated list has a leading prefixed ID (e.g., `TOLD-33,35`): infer the team prefix for bare numbers from the first prefixed ID → `TOLD-33`, `TOLD-35`
+6. Store arrays for the rest of the pipeline:
+   - `ticket_ids` — e.g., `["TOLD-299", "TOLD-300"]`
+   - `ticket_refs` — lowercase refs e.g., `["told-299", "told-300"]`
+   - `primary_ticket_id` — first ticket ID (used for plan file naming and architect focus)
+   - `primary_ticket_ref` — first ticket ref in lowercase (used for plan file and branch naming)
+
+Create the plans directory:
+```bash
+mkdir -p ~/.claude/plans
+```
+
+### Source LINEAR_API_TOKEN
+
+Claude Code's Bash tool does not persist environment variables between calls. Source inline in every Bash call that needs it:
+
+```bash
+# Source LINEAR_API_TOKEN (try file first, ESC fallback)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+if [ -z "${LINEAR_API_TOKEN:-}" ]; then
+  echo "Warning: LINEAR_API_TOKEN not available. Linear API calls will be skipped."
+fi
+```
+
+**IMPORTANT**: Every subsequent Bash call that needs LINEAR_API_TOKEN must inline-source it using the same pattern above.
+
+### Transition tickets to "In Progress"
+
+For EACH ticket_id, transition to "In Progress" in Linear via GraphQL API. Planning means work has started.
+
+```bash
+# Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+if [ -n "${LINEAR_API_TOKEN:-}" ]; then
+  TEAM_KEY="${TICKET_ID%%-*}"
+  STATE_ID=$(resolve_state_id "In Progress" "$TEAM_KEY")  # See /linear skill
+  jq -n --arg id "$TICKET_ID" --arg stateId "$STATE_ID" \
+    '{"query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }", "variables": {"id": $id, "stateId": $stateId}}' \
+    | curl -s -X POST "https://api.linear.app/graphql" \
+      -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @-
+else
+  echo "Warning: LINEAR_API_TOKEN not available — skipping state transition"
+fi
+```
+
+If the call fails (e.g., ticket already in a later state), log a warning and continue — do not stop the pipeline.
+
+> **Best-effort transitions:** Linear API calls are safety nets. If a transition fails, log and continue. The PR body's `Fixes {TEAM}-xxx` handles the Done transition on merge.
+
+## Phase 2: Architect
+
+Spawn a single **architect** subagent to produce the draft plan.
+
+```
+Task(
+  subagent_type: "architect",
+  model: opus,
+  prompt: """
+    Plan implementation for Linear ticket {primary_ticket_id}.
+    {IF multiple tickets}
+    Related tickets: {ticket_ids joined by ', '}. Focus the plan on the primary ticket
+    but note related tickets where relevant.
+    {END}
+
+    Fetch the ticket via Linear GraphQL API using curl:
+    ```bash
+    # Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls in Claude Code)
+    export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
+    [ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+    jq -n --arg id "{primary_ticket_id}" \
+      '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
+      | curl -s -X POST "https://api.linear.app/graphql" \
+        -H "Authorization: $LINEAR_API_TOKEN" -H "Content-Type: application/json" -d @-
+    ```
+    (Best-effort: if the API call fails, proceed without Linear data if unavailable.)
+
+    Write the plan to: ~/.claude/plans/{primary_ticket_ref}.md
+
+    Follow your system prompt for the complete workflow:
+    1. Fetch the Linear ticket
+    2. Deep codebase exploration
+    3. Web research for SOTA patterns
+    4. Write the plan using your template
+  """
+)
+```
+
+### Phase 2 Guard
+
+After the architect completes, verify the plan:
+
+1. Read `~/.claude/plans/{primary_ticket_ref}.md`
+2. Verify it contains `## File Change Map` section
+3. Verify it contains `## Architecture Decisions` section
+4. Verify the File Change Map has at least one `|` table row with a file path
+
+If ANY check fails, spawn a **recovery architect** for a targeted retry:
+
+```
+Task(
+  subagent_type: "architect",
+  prompt: """
+    The previous architect explored the codebase but failed to write the plan file.
+    The plan file at ~/.claude/plans/{primary_ticket_ref}.md is empty or missing required sections.
+
+    Specific failures: {list of failed guard checks}
+
+    Write the plan NOW using the template in your system prompt.
+    Prioritize writing over additional exploration.
+    Read CLAUDE.md for context, then write the plan immediately.
+
+    Write the plan to: ~/.claude/plans/{primary_ticket_ref}.md
+  """
+)
+```
+
+After the recovery architect completes, re-run the same 3 guard checks. If the retry also fails: report "Architect failed to produce a valid plan after retry — missing required sections." → **STOP**
+
+## Phase 3: Lock and Implement
+
+### Lock the plan
+
+Use the Edit tool to replace `STATUS: DRAFT` with `STATUS: LOCKED` in the plan file. Do NOT use `sed -i` (macOS `sed -i ''` can corrupt files).
+
+### Summary
+
+Present a brief summary to the user:
+
+```
+## Plan LOCKED: {primary_ticket_id}
+
+**Title**: {ticket title}
+**Plan**: ~/.claude/plans/{primary_ticket_ref}.md
+```
+
+### Implementation
+
+**Do NOT stop. Do NOT suggest starting a fresh sitting. Implement now.**
+
+The plan is locked. Begin implementation immediately:
+
+1. Read the locked plan file: `~/.claude/plans/{primary_ticket_ref}.md`
+2. Parse the `## File Change Map` table — this is your implementation checklist
+3. Implement each file change in the order specified by the plan
+4. Follow all architecture decisions and patterns specified in the plan
+5. Verify with:
+   ```bash
+   just check    # Validate flake
+   just switch   # Rebuild system
+   just health   # Verify system state
+   ```
+
+After implementation is complete, inform the user and prompt for `/commit` to ship it.

--- a/config/claude-code/skills/plan-ticket/SKILL.md
+++ b/config/claude-code/skills/plan-ticket/SKILL.md
@@ -38,9 +38,8 @@ mkdir -p ~/.claude/plans
 Claude Code's Bash tool does not persist environment variables between calls. Source inline in every Bash call that needs it:
 
 ```bash
-# Source LINEAR_API_TOKEN (try file first, ESC fallback)
-export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
-[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+# Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
 if [ -z "${LINEAR_API_TOKEN:-}" ]; then
   echo "Warning: LINEAR_API_TOKEN not available. Linear API calls will be skipped."
 fi
@@ -53,9 +52,8 @@ fi
 For EACH ticket_id, transition to "In Progress" in Linear via GraphQL API. Planning means work has started.
 
 ```bash
-# Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls)
-export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
-[ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+# Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
+export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
 if [ -n "${LINEAR_API_TOKEN:-}" ]; then
   TEAM_KEY="${TICKET_ID%%-*}"
   STATE_ID=$(resolve_state_id "In Progress" "$TEAM_KEY")  # See /linear skill
@@ -89,9 +87,8 @@ Task(
 
     Fetch the ticket via Linear GraphQL API using curl:
     ```bash
-    # Source LINEAR_API_TOKEN inline (env vars don't persist across Bash calls in Claude Code)
-    export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(cat ~/.config/mcp/linear-api-key 2>/dev/null)}"
-    [ -z "${LINEAR_API_TOKEN:-}" ] && export LINEAR_API_TOKEN="$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')"
+    # Source LINEAR_API_TOKEN from ESC (required: each Bash call is a fresh shell)
+    export LINEAR_API_TOKEN="${LINEAR_API_TOKEN:-$(esc open told/app/local-web --format json 2>/dev/null | jq -r '.environmentVariables.LINEAR_API_TOKEN // empty')}"
     jq -n --arg id "{primary_ticket_id}" \
       '{"query": "query($id: String!) { issue(id: $id) { id identifier title description priority state { name } labels { nodes { name } } assignee { name } team { key } comments { nodes { body createdAt user { name } } } } }", "variables": {"id": $id}}' \
       | curl -s -X POST "https://api.linear.app/graphql" \

--- a/config/quality/src/ci/mcp/index.ts
+++ b/config/quality/src/ci/mcp/index.ts
@@ -36,12 +36,7 @@ const MCP_SERVERS: McpServer[] = [
     args: ['-y', '@modelcontextprotocol/server-github'],
     envVars: { GITHUB_PERSONAL_ACCESS_TOKEN: env.GITHUB_TOKEN },
   },
-  {
-    name: 'linear',
-    executable: 'npx',
-    args: ['-y', 'mcp-remote', 'https://mcp.linear.app/sse'],
-    envVars: {},
-  },
+  // Linear: uses GraphQL API via /linear skill (no MCP server)
 ]
 
 const testServer = (server: McpServer): Effect.Effect<{ name: string; ok: boolean }> =>

--- a/config/quality/src/generators/claude/settings.generator.ts
+++ b/config/quality/src/generators/claude/settings.generator.ts
@@ -129,7 +129,6 @@ const PERMISSIONS = {
     'WebFetch(domain:apps.apple.com)',
 
     'mcp__ref__*',
-    'mcp__linear__*',
   ],
   deny: [
     'Read(**/.env*)',

--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -9,7 +9,7 @@
 # - nix-config.json: Plugins/marketplaces for TypeScript to consume
 #
 # Configuration (April 2026):
-# - 1 MCP server (ref) — Linear at project level
+# - 1 MCP server (ref) — Linear via /linear skill (GraphQL API)
 # - 1 plugin (caveman) — terse output, token savings
 # - 1 extra marketplace (JuliusBrussee/caveman)
 # - 1 DXT extension (Filesystem) - 5 focused allowed directories

--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -57,7 +57,7 @@ let
       url = "https://api.ref.tools/mcp";
       apiKeyPath = "${mcpSecretsPath}/ref-api-key";
     };
-    # Linear MCP configured at project level (Told's .claude/settings.json)
+    # Linear: GraphQL API via /linear skill (no MCP server)
   };
 
   # ═══════════════════════════════════════════════════════════════════════════
@@ -328,6 +328,10 @@ in
       source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude-code/skills";
     };
 
+    home.file.".claude/agents" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude-code/agents";
+    };
+
     home.file.".claude/statusline.sh" = {
       source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude/statusline.sh";
     };
@@ -384,38 +388,40 @@ in
     # Uses jq to MERGE mcpServers + enabledPlugins with existing runtime state
     # Runtime state includes: numStartups, oauthAccount, projects, etc. (31+ keys)
     # 1 server (ref), 1 plugin (caveman)
-    home.activation.generateClaudeCodeConfig = lib.hm.dag.entryAfter [ "writeBoundary" "installPlugins" ] ''
-      MCP_SECRETS="${config.home.homeDirectory}/.config/mcp"
-      CLAUDE_CODE_CONFIG="${config.home.homeDirectory}/.claude.json"
+    home.activation.generateClaudeCodeConfig =
+      lib.hm.dag.entryAfter [ "writeBoundary" "installPlugins" ]
+        ''
+          MCP_SECRETS="${config.home.homeDirectory}/.config/mcp"
+          CLAUDE_CODE_CONFIG="${config.home.homeDirectory}/.claude.json"
 
-      # Read API key for ref server
-      REF_KEY=""
-      [ -f "$MCP_SECRETS/ref-api-key" ] && REF_KEY=$(cat "$MCP_SECRETS/ref-api-key")
+          # Read API key for ref server
+          REF_KEY=""
+          [ -f "$MCP_SECRETS/ref-api-key" ] && REF_KEY=$(cat "$MCP_SECRETS/ref-api-key")
 
-      # MCP servers JSON from Nix SSOT (with placeholders for secrets)
-      MCP_SERVERS='${cliAllJson}'
-      ENABLED_PLUGINS='${enabledPluginsJson}'
+          # MCP servers JSON from Nix SSOT (with placeholders for secrets)
+          MCP_SERVERS='${cliAllJson}'
+          ENABLED_PLUGINS='${enabledPluginsJson}'
 
-      # Substitute placeholder with actual secret value
-      MCP_SERVERS=$(echo "$MCP_SERVERS" | sed "s/__REF_KEY__/$REF_KEY/g")
+          # Substitute placeholder with actual secret value
+          MCP_SERVERS=$(echo "$MCP_SERVERS" | sed "s/__REF_KEY__/$REF_KEY/g")
 
-      # Merge with existing config (preserve runtime state)
-      if [ -f "$CLAUDE_CODE_CONFIG" ]; then
-        MERGED=$(jq --argjson servers "$MCP_SERVERS" --argjson plugins "$ENABLED_PLUGINS" \
-          '.mcpServers = $servers | .enabledPlugins = $plugins | del(.defaultModel)' "$CLAUDE_CODE_CONFIG")
-        # Only write if content actually changed (prevents Claude Code backup spam)
-        CURRENT=$(cat "$CLAUDE_CODE_CONFIG")
-        if [ "$MERGED" != "$CURRENT" ]; then
-          echo "$MERGED" > "$CLAUDE_CODE_CONFIG"
-          echo "Claude Code config updated (1 server, 1 plugin)"
-        else
-          echo "Claude Code config unchanged, skipping write"
-        fi
-      else
-        echo "{\"mcpServers\": $MCP_SERVERS, \"enabledPlugins\": $ENABLED_PLUGINS}" > "$CLAUDE_CODE_CONFIG"
-        echo "Claude Code config created (1 server, 1 plugin)"
-      fi
-    '';
+          # Merge with existing config (preserve runtime state)
+          if [ -f "$CLAUDE_CODE_CONFIG" ]; then
+            MERGED=$(jq --argjson servers "$MCP_SERVERS" --argjson plugins "$ENABLED_PLUGINS" \
+              '.mcpServers = $servers | .enabledPlugins = $plugins | del(.defaultModel)' "$CLAUDE_CODE_CONFIG")
+            # Only write if content actually changed (prevents Claude Code backup spam)
+            CURRENT=$(cat "$CLAUDE_CODE_CONFIG")
+            if [ "$MERGED" != "$CURRENT" ]; then
+              echo "$MERGED" > "$CLAUDE_CODE_CONFIG"
+              echo "Claude Code config updated (1 server, 1 plugin)"
+            else
+              echo "Claude Code config unchanged, skipping write"
+            fi
+          else
+            echo "{\"mcpServers\": $MCP_SERVERS, \"enabledPlugins\": $ENABLED_PLUGINS}" > "$CLAUDE_CODE_CONFIG"
+            echo "Claude Code config created (1 server, 1 plugin)"
+          fi
+        '';
 
     # Install + enable plugins from marketplace via `claude` CLI (idempotent)
     # Runs BEFORE generateClaudeCodeConfig so the jq merge has final say on enabledPlugins.
@@ -423,30 +429,33 @@ in
     # If it fails in darwin-rebuild's sandboxed env, run manually:
     #   claude plugin marketplace add JuliusBrussee/caveman --scope user
     #   claude plugin install caveman@caveman --scope user
-    home.activation.installPlugins = lib.hm.dag.entryAfter [
-      "writeBoundary"
-    ] ''
-      CLAUDE="/etc/profiles/per-user/${config.home.username}/bin/claude"
+    home.activation.installPlugins =
+      lib.hm.dag.entryAfter
+        [
+          "writeBoundary"
+        ]
+        ''
+          CLAUDE="/etc/profiles/per-user/${config.home.username}/bin/claude"
 
-      if [ -x "$CLAUDE" ]; then
-        # Check if caveman is already installed (skip network-dependent install)
-        if $CLAUDE plugin list 2>/dev/null | grep -q "caveman@caveman"; then
-          echo "Caveman plugin already installed"
-        else
-          echo "Caveman plugin not found, attempting install..."
-          # Add marketplace (requires git clone — may fail in sandboxed env)
-          if $CLAUDE plugin marketplace add JuliusBrussee/caveman --scope user 2>&1; then
-            $CLAUDE plugin install caveman@caveman --scope user 2>&1 || \
-              echo "WARN: caveman install failed — run manually: claude plugin install caveman@caveman --scope user"
+          if [ -x "$CLAUDE" ]; then
+            # Check if caveman is already installed (skip network-dependent install)
+            if $CLAUDE plugin list 2>/dev/null | grep -q "caveman@caveman"; then
+              echo "Caveman plugin already installed"
+            else
+              echo "Caveman plugin not found, attempting install..."
+              # Add marketplace (requires git clone — may fail in sandboxed env)
+              if $CLAUDE plugin marketplace add JuliusBrussee/caveman --scope user 2>&1; then
+                $CLAUDE plugin install caveman@caveman --scope user 2>&1 || \
+                  echo "WARN: caveman install failed — run manually: claude plugin install caveman@caveman --scope user"
+              else
+                echo "WARN: marketplace add failed (likely SSH/sandbox restriction)"
+                echo "  Run manually: claude plugin marketplace add JuliusBrussee/caveman --scope user"
+              fi
+            fi
           else
-            echo "WARN: marketplace add failed (likely SSH/sandbox restriction)"
-            echo "  Run manually: claude plugin marketplace add JuliusBrussee/caveman --scope user"
+            echo "WARN: claude CLI not found, skipping plugin install"
           fi
-        fi
-      else
-        echo "WARN: claude CLI not found, skipping plugin install"
-      fi
-    '';
+        '';
 
     # generateClaudeCodeConfig runs AFTER installPlugins — its jq merge
     # overwrites enabledPlugins with Nix SSOT, ensuring caveman stays enabled


### PR DESCRIPTION
## Summary
- Add `/linear` skill — manage Linear tickets via GraphQL API (`curl + jq`), replacing the Linear MCP server (no OAuth re-auth, no stalls)
- Add `/plan-ticket` skill — simplified 3-phase planning pipeline (setup → architect → lock+implement) adapted from Told's 6-phase version
- Add `architect` agent — dotfiles-specific plan architect with Nix constraints
- Add `.claude/agents` symlink in `claude.nix` for agent discovery
- Remove `mcp__linear__*` permission from settings generator (no MCP)
- Remove Linear MCP smoke test from CI
- Update `CLAUDE.md` with new skills and vendor skills section

Credential sourcing: `~/.config/mcp/linear-api-key` with Pulumi ESC fallback.

Fixes TOLD-1707

## Test plan
- [ ] `nix flake check` passes
- [ ] `just switch` activates symlinks (`ls -la ~/.claude/agents/`)
- [ ] `/linear get TOLD-1707` fetches ticket details
- [ ] `/linear transition TOLD-1707 'In Review'` updates ticket state
- [ ] `/plan-ticket TOLD-XXX` spawns architect and produces plan