### PR TITLE
feat(claude): add max-4 account and enrich max-3 metadata

### DIFF
--- a/config/claude/statusline.sh
+++ b/config/claude/statusline.sh
@@ -36,6 +36,7 @@ elif [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
   case "${CLAUDE_CONFIG_DIR##*/}" in
     .claude-max-2) account="max-2" ;;
     .claude-max-3) account="max-3" ;;
+    .claude-max-4) account="max-4" ;;
     *) account="max-1" ;;
   esac
 else

--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -64,6 +64,15 @@ let
       model = "opus";
     }
     {
+      name = "max-4";
+      configDir = ".claude-max-4";
+      provider = "anthropic";
+      description = "Max 20x — overflow 3";
+      email = ""; # TBD — set after account creation
+      authMethod = "claude.ai";
+      model = "opus";
+    }
+    {
       name = "glm";
       configDir = null;
       provider = "zai";


### PR DESCRIPTION
## Summary
- Add max-4 to accountDefs in claude.nix with configDir, metadata fields (email, authMethod, model)
- Enrich max-3 entry with email (eng@told.one), authMethod, and model metadata
- Add max-4 to cc shell function: fzf picker, case routing, help text, _cc_status
- Add max-4 case to statusline.sh account identity detection

## Human steps required after merge
1. `just switch` to deploy (creates ~/.claude-max-4/ with symlinks)
2. Create max-4 account on claude.ai + subscribe Max 20x
3. `CLAUDE_CONFIG_DIR=$HOME/.claude-max-4 claude auth login`
4. Run `cc status` to verify all 4 accounts

Fixes TOLD-1732