### PR TITLE
feat(claude): update cc openai to gpt-5.3-codex via openrouter

### DIFF
--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -451,7 +451,7 @@ let
             "  [[ -z \"$key\" ]] && { echo \"ERROR: Secret ${acct.secretId} missing\" >&2; exit 1; }"
             "  ANTHROPIC_BASE_URL=\"https://openrouter.ai/api\" \\"
             "  ANTHROPIC_AUTH_TOKEN=\"$key\" \\"
-            "  ANTHROPIC_MODEL=\"openai/gpt-5.3-codex\" \\"
+            "  ANTHROPIC_MODEL=\"openai/${acct.model}\" \\
             "  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \\"
             "  claude \"$@\" ;;"
           ]


### PR DESCRIPTION
## Summary
- Update `cc openai` model slug from `gpt-5` to `gpt-5.3-codex` ($1.75/$14 per MTok, 400K context)
- Fix hardcoded model in `mkCaseBranch` openrouter branch to use SSOT `acct.model` field
- OpenRouter API key stored in AWS Secrets Manager at `told/vendor/openrouter/api-key`

## Test plan
- [ ] `just switch` succeeds
- [ ] `grep ANTHROPIC_MODEL ~/.config/just/justfile` shows `openai/gpt-5.3-codex`
- [ ] `cc openai -p "What model are you?"` returns GPT-5.3-Codex response
- [ ] `cc status` shows openai key as OK

Fixes TOLD-1754