### PR TITLE
ci: harden unified pipeline cache behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0.2.0
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: ${{ env.BUN_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,25 +22,33 @@ jobs:
   # ===========================================================================
   unified-pipeline:
     name: Unified Pipeline
-    runs-on: ubuntu-24.04-arm
-
-    container:
-      image: oven/bun:1.3.5-debian
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install System Dependencies
         run: |
-          apt-get update
-          apt-get install -y xz-utils curl git ripgrep fd-find python3 python3-yaml
+          sudo apt-get update
+          sudo apt-get install -y xz-utils curl git ripgrep fd-find python3 python3-yaml
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+        timeout-minutes: 3
 
       - name: Setup Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        timeout-minutes: 2
+        continue-on-error: true
 
       - name: Install dependencies
         run: bun install
@@ -63,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
 
       - name: Install dependencies
         run: bun install
@@ -96,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Tools
         run: |


### PR DESCRIPTION
## Summary
- run `Unified Pipeline` on `ubuntu-latest` host runner (remove containerized Bun path)
- pin action versions: `actions/checkout@v6`, `oven-sh/setup-bun@v2.2.0`, `DeterminateSystems/nix-installer-action@v22`, `DeterminateSystems/magic-nix-cache-action@v13`
- make Nix/cache setup resilient with timeout + non-blocking cache and OIDC permissions

## Test plan
- [x] Verify workflow diff is limited to `.github/workflows/ci.yml`
- [ ] Confirm next CI run no longer hangs indefinitely at `Setup Nix Cache`
- [ ] Confirm `Unified Pipeline` continues through `bun run ci`
