### PR TITLE
docs(codex): add readiness assessment, runbook, and install hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Dotfiles
+
+Nix-managed macOS configuration for senior engineer building Told (voice memory platform).
+
+> This file mirrors critical rules from CLAUDE.md for Codex CLI sessions.
+> Quality hooks, skills, and commands are Claude Code specific and not available here.
+
+## Quick Commands
+
+```bash
+just switch        # Rebuild darwin + home-manager
+just check         # Validate flake
+just health        # Verify system state
+```
+
+## Architecture
+
+```
+flake.nix                    # Entry point
+├── modules/darwin/          # macOS system (dock, keyboard, services)
+├── modules/home/            # User config (shell, apps, tools)
+│   └── apps/claude.nix     # Claude SSOT (MCP, plugins, marketplaces)
+├── config/quality/          # Claude Code hooks + settings generator
+│   ├── docs/               # Guards architecture & ADRs
+│   ├── src/hooks/          # Pre/Post tool enforcement (Claude Code only)
+│   ├── src/stack/          # versions.ts SSOT
+│   ├── src/generators/     # settings.json generator
+│   └── generated/          # Output (DO NOT EDIT)
+├── config/claude/commands/  # Slash commands (Claude Code only)
+├── config/claude-code/      # Skills + agents (Claude Code only)
+└── hosts/                   # Machine-specific config
+```
+
+## Runtime Convention
+
+- **bun**: scripts, MCP servers, tooling wrappers, config/quality hooks, pkgs/*.nix CLI wrappers
+- **pnpm + Node.js**: application code (~/src/told), devshells, production
+
+## Rules
+
+- All Claude/Codex config via Nix (never edit ~/.claude/ or ~/.codex/ manually)
+- Told is the primary project (Effect-TS, Expo SDK 54, LiveKit)
+- Run `just check` before committing Nix changes
+- Format with biome, lint with oxlint, typecheck with tsgo for TypeScript files
+
+## Stack (Mar 2026)
+
+| Category | Tools |
+|----------|-------|
+| Runtime | Node 25, pnpm 10, TypeScript 5.9 |
+| Types | tsgo (native preview) for compilation |
+| Lint | oxlint (690+ rules, type-aware) |
+| Format | biome (format only, no lint) |
+| Backend | Effect-TS 3.19, HttpApi, Schema, Layer |
+| Frontend | React 19.2, XState 5.25, TanStack Router |
+| Mobile | Expo SDK 54, React Native 0.81, NativeWind |
+| Voice | LiveKit 2.16, @livekit/agents |
+| Infra | Pulumi 3.217, AWS ECS, CloudFront |
+
+## Key Files
+
+- `modules/home/apps/claude.nix` - Claude SSOT (MCP, plugins, marketplaces)
+- `config/quality/src/stack/versions.ts` - Version SSOT
+- `config/quality/docs/ARCHITECTURE.md` - Guards architecture
+- `config/quality/docs/adr/` - Architecture Decision Records
+
+## Quality (Manual in Codex Sessions)
+
+Claude Code enforces quality via PreToolUse/PostToolUse hooks. Codex has no hook equivalent. Manually verify before committing:
+
+```bash
+# TypeScript
+bunx biome format --write .     # Format
+bunx oxlint .                   # Lint
+
+# Nix
+nixfmt .                        # Format
+statix check .                  # Lint
+deadnix .                       # Dead code
+just check                      # Flake validation
+```

--- a/config/quality/docs/adr/014-codex-cli-readiness.md
+++ b/config/quality/docs/adr/014-codex-cli-readiness.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+date: 2026-04-15
+decision-makers: [Hank Lee]
+consulted: []
+informed: []
+---
+
+# Codex CLI readiness: install path, auth model, and compatibility assessment
+
+## Context and Problem Statement
+
+OpenAI's Codex CLI is a viable fallback coding agent when Claude Code is unavailable (provider outage, rate limits). Before integrating it into the dotfiles workflow, we need to assess operational readiness: install status, auth path, and compatibility with existing quality infrastructure. How should we install and configure Codex CLI alongside Claude Code without disrupting existing workflows?
+
+## Decision Drivers
+
+* Provider redundancy — avoid single-provider lock-in for AI coding assistance
+* Minimal disruption — existing Claude Code quality guards, hooks, and skills must continue working
+* Nix-managed — installation should be declarative and reproducible
+* Low maintenance — assessment phase, not full integration
+
+## Considered Options
+
+* Option A: Homebrew formula
+* Option B: npm global install via home-manager activation hook
+* Option C: Custom Nix derivation in pkgs/
+
+## Decision Outcome
+
+Chosen option: "Option B — npm global install via activation hook", because Codex CLI is not in nixpkgs or Homebrew core, npm is the canonical install path, and an activation hook follows the established `setupUvTools` pattern in `common.nix`. Can be promoted to a proper Nix derivation later if Codex becomes a daily driver.
+
+### Consequences
+
+* Good, because installation is declarative and idempotent via home-manager activation
+* Good, because Node 25 already meets Codex's Node 22+ requirement
+* Good, because Codex sessions can use MCP servers (ref) via `codex mcp add`
+* Bad, because Codex sessions run without quality guards (no hook equivalent exists)
+* Bad, because Claude Code skills/commands (`/commit`, `/linear`, `/plan-ticket`) have no Codex equivalent
+* Neutral, because AGENTS.md can mirror critical CLAUDE.md rules but not enforce them
+
+### Confirmation
+
+* `codex --version` returns a version after `just switch`
+* `AGENTS.md` exists at repo root and is picked up by Codex sessions
+* Runbook at `config/quality/docs/codex-runbook.md` covers install, auth, MCP, and switching
+* Claude Code workflows remain unaffected (`cc`, `just -g cc`, hooks, skills all work)
+
+## Pros and Cons of the Options
+
+### Option A: Homebrew formula
+
+* Good, because Homebrew is already used for many CLI tools
+* Bad, because `@openai/codex` is not in Homebrew core (would need a tap or manual formula)
+* Bad, because Homebrew node dependency management is less predictable
+
+### Option B: npm global install via activation hook
+
+* Good, because npm is the canonical install path (`npm i -g @openai/codex`)
+* Good, because follows established `setupUvTools` pattern in `common.nix`
+* Good, because idempotent — only installs/upgrades when version differs
+* Neutral, because npm global installs are outside Nix's dependency graph
+
+### Option C: Custom Nix derivation
+
+* Good, because fully Nix-managed with reproducible builds
+* Bad, because Codex CLI has complex npm dependencies that are hard to package
+* Bad, because overkill for an assessment phase — high effort, low immediate value
+
+## More Information
+
+### Compatibility Matrix
+
+| Feature | Claude Code | Codex CLI | Gap |
+|---------|------------|-----------|-----|
+| Config format | JSON | TOML | Medium — cannot share config |
+| Instruction files | CLAUDE.md | AGENTS.md | Low — content adaptable |
+| Hooks (PreToolUse etc.) | Yes (6 hooks) | No equivalent | **High** |
+| Skills/Commands | Yes (12+) | No equivalent | **High** |
+| MCP support | Yes (JSON) | Yes (TOML) | Low — same servers |
+| Multi-account | CLAUDE_CONFIG_DIR | CODEX_HOME | Low |
+| Permissions | Fine-grained allow/deny | 3 approval modes | Medium |
+| Nix integration | Deep | None | **High** |
+
+3 high-severity gaps mean Codex is suitable as a **fallback provider only**, not a primary workflow replacement.
+
+Related: [Codex CLI docs](https://developers.openai.com/codex/cli), [Codex config reference](https://developers.openai.com/codex/config-reference)

--- a/config/quality/docs/codex-runbook.md
+++ b/config/quality/docs/codex-runbook.md
@@ -1,0 +1,165 @@
+# Codex CLI Runbook
+
+Operational guide for using OpenAI Codex CLI alongside Claude Code in the dotfiles-managed environment.
+
+**Decision**: ADR-014 — Codex CLI is a fallback provider, not a primary workflow replacement.
+
+## Prerequisites
+
+- Node 22+ (Node 25 installed via Nix)
+- OpenAI account: ChatGPT Plus/Pro/Business/Edu/Enterprise OR API key
+- Dotfiles rebuilt: `just switch` (installs Codex via activation hook)
+
+## Installation
+
+Codex CLI is installed automatically by the `setupCodexCli` activation hook in `modules/home/packages/common.nix`.
+
+```bash
+# Verify installation
+codex --version
+
+# Manual install/upgrade (if activation hook hasn't run)
+npm i -g @openai/codex@latest
+```
+
+## Authentication
+
+Two auth methods:
+
+### ChatGPT Account (Recommended)
+
+```bash
+codex          # First run triggers browser-based OAuth login
+# OR
+codex auth login
+```
+
+Login credentials stored locally. No API key needed.
+
+### API Key
+
+```bash
+export OPENAI_API_KEY="sk-..."
+codex
+```
+
+Or set in config:
+
+```toml
+# ~/.codex/config.toml
+[auth]
+cli_auth_credentials_store = "keychain"  # macOS Keychain
+```
+
+## MCP Configuration
+
+The `ref` MCP server (primary documentation tool) works with Codex:
+
+```bash
+# Add ref server (same server used by Claude Code)
+codex mcp add ref --type http --url "https://ref.tools/mcp"
+
+# Verify
+codex mcp list
+
+# Remove if needed
+codex mcp remove ref
+```
+
+## AGENTS.md
+
+Codex reads `AGENTS.md` at the repo root (analogous to `CLAUDE.md`). The dotfiles repo includes an `AGENTS.md` that mirrors critical rules from `CLAUDE.md`:
+
+- Architecture overview and directory structure
+- Runtime conventions (bun vs pnpm)
+- Core rules (Nix-managed config, quality enforcement)
+- Stack versions
+- Key files
+
+**Not included** (Claude Code specific): hooks, skills/commands, plugins, MCP JSON config.
+
+Discovery chain: `~/.codex/AGENTS.override.md` > `~/.codex/AGENTS.md` > project root walk. 32 KiB limit.
+
+## Approval Modes
+
+| Mode | Behavior | Use When |
+|------|----------|----------|
+| Auto (default) | Workspace-scoped writes auto-approved | Normal development |
+| Read-only | Consultative, no writes | Code review, exploration |
+| Full Access | Unrestricted | Trusted automation |
+
+```bash
+codex --approval-mode read-only   # Start in read-only
+codex --approval-mode full-auto   # Start in full access
+```
+
+## Switching Workflow
+
+### When to use Codex
+
+- Claude Code is down (provider outage)
+- Rate-limited on all Claude accounts
+- Task needs OpenAI model capabilities (e.g., specific model strengths)
+- Quick exploration where quality hooks aren't needed
+
+### When to stay on Claude Code
+
+- Any task requiring quality guards (format, lint, typecheck enforcement)
+- Workflow commands needed (`/commit`, `/linear`, `/plan-ticket`)
+- MCP servers already configured and working
+- Multi-account switching via `just -g cc`
+
+### Switching procedure
+
+```bash
+# Claude Code (primary)
+cc                    # Or: just -g cc
+
+# Codex (fallback)
+codex                 # In any project directory
+
+# Both can run independently in separate terminals
+```
+
+## Compatibility Matrix
+
+| Feature | Claude Code | Codex CLI | Status |
+|---------|------------|-----------|--------|
+| Installation | Nix package | npm global (activation hook) | Working |
+| Config format | JSON (settings.json) | TOML (config.toml) | Separate configs |
+| Instruction file | CLAUDE.md | AGENTS.md | Both present |
+| PreToolUse hooks | 6 quality guards | None | **Not portable** |
+| PostToolUse hooks | Yes | None | **Not portable** |
+| Skills (/commit etc.) | 12+ skills | None | **Not portable** |
+| Commands | 6+ commands | None | **Not portable** |
+| MCP servers | Auto-configured via Nix | Manual `codex mcp add` | Manual setup |
+| Multi-account | 5 accounts via justfile | Single account | Manual switch |
+| Permissions | Fine-grained allow/deny | 3 approval modes | Less granular |
+| Plugins | caveman (1) | None | **Not portable** |
+
+## Known Limitations
+
+1. **No quality hooks**: Format, lint, typecheck enforcement does not run in Codex sessions. Code quality must be verified manually after Codex sessions.
+2. **No skills/commands**: `/commit`, `/linear`, `/plan-ticket` etc. are Claude Code specific. Use git CLI directly.
+3. **No multi-account launcher**: `just -g cc` picker is Claude Code only. Run `codex` directly.
+4. **Less granular permissions**: 3 approval modes vs Claude Code's per-tool allow/deny lists.
+5. **Manual MCP setup**: MCP servers must be added manually via `codex mcp add` (not auto-configured).
+6. **No plugin ecosystem**: Caveman mode and other plugins unavailable.
+
+## Troubleshooting
+
+```bash
+# Codex not found after just switch
+npm i -g @openai/codex@latest    # Manual install
+
+# Auth issues
+codex auth logout && codex auth login
+
+# MCP server not connecting
+codex mcp list                    # Verify config
+codex mcp remove ref && codex mcp add ref --type http --url "..."
+
+# Version check
+codex --version
+node --version                    # Must be 22+
+```

--- a/modules/home/packages/common.nix
+++ b/modules/home/packages/common.nix
@@ -67,5 +67,22 @@ in
         echo "uv setup complete: Python 3.14 + ruff"
       fi
     '';
+
+    # Codex CLI - OpenAI's coding agent (fallback provider, see ADR-014)
+    home.activation.setupCodexCli = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      NPM="/etc/profiles/per-user/${config.home.username}/bin/npm"
+
+      if [ -x "$NPM" ]; then
+        CURRENT=$("$NPM" list -g @openai/codex --depth=0 2>/dev/null | grep @openai/codex | sed 's/.*@openai\/codex@//' || true)
+        LATEST=$("$NPM" view @openai/codex version 2>/dev/null || true)
+
+        if [ -z "$CURRENT" ] || [ "$CURRENT" != "$LATEST" ]; then
+          echo "Installing @openai/codex@''${LATEST:-latest}..."
+          "$NPM" i -g @openai/codex@latest 2>/dev/null || true
+        else
+          echo "Codex CLI up to date: $CURRENT"
+        fi
+      fi
+    '';
   };
 }


### PR DESCRIPTION
## Summary

- Add ADR-014 documenting Codex CLI readiness assessment (install path, auth model, compatibility gaps)
- Add operational runbook with install, auth, MCP config, and switching workflow
- Add `setupCodexCli` activation hook in `common.nix` (follows `setupUvTools` pattern)
- Add repo-root `AGENTS.md` instruction file for Codex CLI sessions

**Decision**: Support Codex as fallback provider only. 3 high-severity gaps (hooks, skills, Nix integration) mean it cannot replace Claude Code as primary workflow.

## Test plan

- [ ] `just check` passes (flake validation)
- [ ] `just switch` installs Codex CLI via activation hook
- [ ] `codex --version` returns version after rebuild
- [ ] Claude Code workflows unaffected (`cc`, hooks, skills)
- [ ] `AGENTS.md` picked up by Codex sessions in dotfiles root

Fixes TOLD-1768