### PR TITLE
feat(shell): consolidate launcher model policy + explicit account statusline

### DIFF
--- a/config/claude/statusline.sh
+++ b/config/claude/statusline.sh
@@ -26,8 +26,9 @@ IFS=$'\t' read -r model_id cost duration_ms lines_added lines_removed cwd contex
 # ═══════════════════════════════════════════════════
 # 2. Account identity (from env vars, no subprocess)
 # ═══════════════════════════════════════════════════
-account="max-1"
-if [[ "${ANTHROPIC_BASE_URL:-}" == *"z.ai"* ]]; then
+if [[ -n "${AI_ACCOUNT:-}" ]]; then
+  account="$AI_ACCOUNT"
+elif [[ "${ANTHROPIC_BASE_URL:-}" == *"z.ai"* ]]; then
   account="glm"
 elif [[ "${ANTHROPIC_BASE_URL:-}" == *"openrouter"* ]]; then
   account="openai"
@@ -35,7 +36,10 @@ elif [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
   case "${CLAUDE_CONFIG_DIR##*/}" in
     .claude-max-2) account="max-2" ;;
     .claude-max-3) account="max-3" ;;
+    *) account="max-1" ;;
   esac
+else
+  account="max-1"
 fi
 
 # ═══════════════════════════════════════════════════

--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -426,9 +426,9 @@ let
           [
             (
               if acct.configDir != null then
-                ''${acct.name}) CLAUDE_CONFIG_DIR="$HOME/${acct.configDir}" claude "$@" ;;''
+                ''${acct.name}) AI_ACCOUNT="${acct.name}" CLAUDE_CONFIG_DIR="$HOME/${acct.configDir}" claude "$@" ;;''
               else
-                ''${acct.name}) unset CLAUDE_CONFIG_DIR; claude "$@" ;;''
+                ''${acct.name}) unset CLAUDE_CONFIG_DIR; AI_ACCOUNT="${acct.name}" claude "$@" ;;''
             )
           ]
         else if acct.provider == "zai" then
@@ -442,6 +442,7 @@ let
             "  ANTHROPIC_DEFAULT_SONNET_MODEL=\"glm-5.1\" \\"
             "  ANTHROPIC_DEFAULT_HAIKU_MODEL=\"glm-4.5-air\" \\"
             "  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \\"
+            "  AI_ACCOUNT=\"${acct.name}\" \\"
             "  claude \"$@\" ;;"
           ]
         else if acct.provider == "openrouter" then
@@ -451,8 +452,9 @@ let
             "  [[ -z \"$key\" ]] && { echo \"ERROR: Secret ${acct.secretId} missing\" >&2; exit 1; }"
             "  ANTHROPIC_BASE_URL=\"https://openrouter.ai/api\" \\"
             "  ANTHROPIC_AUTH_TOKEN=\"$key\" \\"
-            "  ANTHROPIC_MODEL=\"openai/${acct.model}\" \\
+            "  ANTHROPIC_MODEL=\"openai/${acct.model}\" \\"
             "  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \\"
+            "  AI_ACCOUNT=\"${acct.name}\" \\"
             "  claude \"$@\" ;;"
           ]
         else

--- a/modules/home/shell/aliases.nix
+++ b/modules/home/shell/aliases.nix
@@ -103,8 +103,6 @@ in
       ccd = "claude --dangerously-skip-permissions";
       ccr = "claude --resume";
       ccc = "claude --continue";
-      ccplan = "claude --model claude-opus-4-5-20251101";
-      ccfast = "claude --model claude-sonnet-4-5-20250929";
       ccnew = "claude --new";
       ccv = "claude --verbose";
 


### PR DESCRIPTION
## Summary
- Remove legacy `ccplan`/`ccfast` aliases superseded by `just -g cc` launcher
- Add `AI_ACCOUNT` env var to all provider branches (anthropic, zai, openrouter) in `mkCaseBranch` so statusline identifies accounts explicitly
- Fix OpenRouter Nix string termination bug (multiline string boundary)
- Update `statusline.sh` to prefer `AI_ACCOUNT` with heuristic fallback for backward compatibility

## Test plan
- [ ] `nix flake check` passes
- [ ] `just switch` rebuilds successfully
- [ ] `grep AI_ACCOUNT ~/.config/just/justfile` shows marker in all case branches
- [ ] `type ccplan` and `type ccfast` return not found in new shell
- [ ] `just -g cc status` works for all accounts
- [ ] Statusline shows correct account with and without `AI_ACCOUNT` set

Fixes TOLD-1772