### PR TITLE
docs(codex): AGENTS.md drift governance [TOLD-1773]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,17 @@ flake.nix                    # Entry point
 | Voice | LiveKit 2.16, @livekit/agents |
 | Infra | Pulumi 3.217, AWS ECS, CloudFront |
 
+## Codex Cross-Reference
+
+This is the Codex-compatible instruction file. See `CLAUDE.md` for the full Claude Code configuration including hooks, skills, agents, and MCP servers.
+
 ## Key Files
 
 - `modules/home/apps/claude.nix` - Claude SSOT (MCP, plugins, marketplaces)
 - `config/quality/src/stack/versions.ts` - Version SSOT
 - `config/quality/docs/ARCHITECTURE.md` - Guards architecture
 - `config/quality/docs/adr/` - Architecture Decision Records
+- `config/quality/docs/drift-governance.md` - AGENTS.md drift governance process
 
 ## Quality (Manual in Codex Sessions)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,10 @@ See [ADR-009](config/quality/docs/adr/009-network-api-toolkit.md) for full detai
 
 - **Told guard gap**: When working in ~/src/told, Told's PreToolUse replaces dotfiles' PreToolUse via deep merge with array replacement. Guards 3 (forbidden files), 32 (secrets detection), 33 (hook bypass prevention) do NOT run in Told. Tracked in Linear.
 
+## Codex Cross-Reference
+
+`AGENTS.md` at repo root is the Codex-compatible instruction file — a subset of this file excluding hooks, skills, agents, and MCP config. See `config/quality/docs/drift-governance.md` for the sync process.
+
 ## Key Files
 
 - `modules/home/apps/claude.nix` - Claude SSOT (MCP, plugins, marketplaces)

--- a/config/quality/docs/codex-runbook.md
+++ b/config/quality/docs/codex-runbook.md
@@ -68,15 +68,22 @@ codex mcp remove ref
 
 ## AGENTS.md
 
-Codex reads `AGENTS.md` at the repo root (analogous to `CLAUDE.md`). The dotfiles repo includes an `AGENTS.md` that mirrors critical rules from `CLAUDE.md`:
+Codex reads `AGENTS.md` at the repo root (analogous to `CLAUDE.md`). Both managed repos have an `AGENTS.md`:
 
+| Repo | File | Status |
+|------|------|--------|
+| `~/dotfiles` | `AGENTS.md` | Mirrors critical rules from CLAUDE.md |
+| `~/src/told` | `AGENTS.md` | Codex-compatible subset of told's CLAUDE.md |
+
+Each AGENTS.md includes:
 - Architecture overview and directory structure
-- Runtime conventions (bun vs pnpm)
-- Core rules (Nix-managed config, quality enforcement)
-- Stack versions
-- Key files
+- Stack versions and key files
+- Code rules (absolute rules, imports, git workflow)
+- Manual quality verification commands
 
-**Not included** (Claude Code specific): hooks, skills/commands, plugins, MCP JSON config.
+**Not included** (Claude Code specific): hooks, skills/commands, agents, domain rules, plugins, MCP JSON config.
+
+**Drift governance:** See `config/quality/docs/drift-governance.md` for the sync process and trigger checklist. Run `config/quality/scripts/check-agents-drift.sh` to detect structural drift.
 
 Discovery chain: `~/.codex/AGENTS.override.md` > `~/.codex/AGENTS.md` > project root walk. 32 KiB limit.
 

--- a/config/quality/docs/drift-governance.md
+++ b/config/quality/docs/drift-governance.md
@@ -1,0 +1,56 @@
+# AGENTS.md Drift Governance
+
+Process for keeping AGENTS.md files in sync with their corresponding CLAUDE.md files across repos.
+
+**Scope:** `~/dotfiles` and `~/src/told` — both maintain separate AGENTS.md (Codex) and CLAUDE.md (Claude Code) files.
+
+**Design:** Two-copy, no symlinks. AGENTS.md is intentionally smaller (Codex-compatible subset). Content drift is expected; structural drift is not.
+
+## Trigger Checklist
+
+Update AGENTS.md when any of these change in CLAUDE.md:
+
+| Trigger | Example |
+|---------|---------|
+| Stack version changes | versions.ts, pnpm-workspace.yaml catalog |
+| Repo structure changes | New apps, packages, or top-level dirs |
+| Git workflow changes | Branch naming, PR format, commit conventions |
+| Absolute rules changes | AST-grep rules added/removed/modified |
+| Import convention changes | Barrel export rules, extension rules |
+| Deployment pipeline changes | New stages, rollback procedures |
+| CLI command changes | New commands, renamed commands |
+| Key files changes | New critical files, removed files |
+
+## Ownership
+
+Hank (sole engineer). Updates both files when triggers fire.
+
+## Cadence
+
+- **On-demand:** When trigger events occur during normal development
+- **Monthly spot-check:** Calendar reminder to run drift check script
+- **Pre-release:** Before major infrastructure or architecture changes
+
+## Drift Check Script
+
+Run `config/quality/scripts/check-agents-drift.sh` to detect structural drift:
+
+```bash
+bash config/quality/scripts/check-agents-drift.sh
+```
+
+The script checks:
+1. Both repos have AGENTS.md files present
+2. Section headers in AGENTS.md have corresponding CLAUDE.md sections
+3. Stack version numbers match between AGENTS.md and CLAUDE.md (per repo)
+4. File sizes are under 32 KiB (Codex discovery chain limit)
+
+**Not checked** (intentionally different): line-by-line content, Claude-only sections absent from AGENTS.md, section ordering.
+
+## Recovery
+
+If drift is detected:
+1. Read the current CLAUDE.md for the affected repo
+2. Update AGENTS.md to reflect current state
+3. Commit with message: `docs(agents): sync AGENTS.md with CLAUDE.md`
+4. Re-run drift check to confirm resolution

--- a/config/quality/scripts/check-agents-drift.sh
+++ b/config/quality/scripts/check-agents-drift.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# check-agents-drift.sh — Detect AGENTS.md vs CLAUDE.md structural drift
+# Run from dotfiles repo root: bash config/quality/scripts/check-agents-drift.sh
+
+set -euo pipefail
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+TOLD_DIR="${TOLD_DIR:-$HOME/src/told}"
+MAX_SIZE=32768  # 32 KiB Codex limit
+ERRORS=0
+
+red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$1"; }
+
+check_exists() {
+  local repo="$1" file="$2"
+  if [ ! -f "$repo/$file" ]; then
+    red "FAIL: $repo/$file does not exist"
+    ERRORS=$((ERRORS + 1))
+    return 1
+  fi
+  return 0
+}
+
+check_size() {
+  local file="$1"
+  local size
+  size=$(wc -c < "$file")
+  if [ "$size" -gt "$MAX_SIZE" ]; then
+    red "FAIL: $file is ${size} bytes (limit: ${MAX_SIZE})"
+    ERRORS=$((ERRORS + 1))
+  else
+    green "OK: $file is ${size} bytes (under ${MAX_SIZE} limit)"
+  fi
+}
+
+check_sections() {
+  local repo_name="$1" agents="$2" claude="$3"
+  # Extract ## headings from AGENTS.md (skip Claude-only boundary section)
+  local agents_sections
+  agents_sections=$(grep -E '^## ' "$agents" | grep -v 'Claude Code vs Codex' | sed 's/^## //' | sort)
+
+  local missing=0
+  while IFS= read -r section; do
+    if ! grep -qF "## $section" "$claude"; then
+      yellow "WARN: $repo_name AGENTS.md section '## $section' has no match in CLAUDE.md"
+      missing=$((missing + 1))
+    fi
+  done <<< "$agents_sections"
+
+  if [ "$missing" -eq 0 ]; then
+    green "OK: $repo_name — all AGENTS.md sections found in CLAUDE.md"
+  fi
+}
+
+check_stack_versions() {
+  local repo_name="$1" agents="$2" claude="$3"
+  # Extract first column (component name) from AGENTS.md stack table
+  # Check each AGENTS.md entry exists in CLAUDE.md (subset check, not exact match)
+  local agents_components
+  agents_components=$(awk '/^## Stack/,/^## [^S]/' "$agents" \
+    | grep -F '|' | grep -Fv -- '---' | grep -Fv 'Component' | grep -Fv 'Category' \
+    | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}' | sort)
+
+  if [ -z "$agents_components" ]; then
+    yellow "WARN: $repo_name AGENTS.md has no stack table rows"
+    return
+  fi
+
+  local missing=0
+  while IFS= read -r component; do
+    [ -z "$component" ] && continue
+    if ! grep -Fq "$component" "$claude"; then
+      yellow "WARN: $repo_name — AGENTS.md component '$component' not found in CLAUDE.md"
+      missing=$((missing + 1))
+    fi
+  done <<< "$agents_components"
+
+  if [ "$missing" -eq 0 ]; then
+    green "OK: $repo_name — all AGENTS.md stack entries present in CLAUDE.md"
+  else
+    ERRORS=$((ERRORS + missing))
+  fi
+}
+
+echo "=== AGENTS.md Drift Check ==="
+echo ""
+
+# 1. File existence
+echo "--- File Existence ---"
+dotfiles_agents=0
+dotfiles_claude=0
+told_agents=0
+told_claude=0
+
+check_exists "$DOTFILES_DIR" "AGENTS.md" && dotfiles_agents=1
+check_exists "$DOTFILES_DIR" "CLAUDE.md" && dotfiles_claude=1
+check_exists "$TOLD_DIR" "AGENTS.md" && told_agents=1
+check_exists "$TOLD_DIR" "CLAUDE.md" && told_claude=1
+echo ""
+
+# 2. Size checks
+echo "--- Size Check (32 KiB limit) ---"
+[ "$dotfiles_agents" -eq 1 ] && check_size "$DOTFILES_DIR/AGENTS.md"
+[ "$told_agents" -eq 1 ] && check_size "$TOLD_DIR/AGENTS.md"
+echo ""
+
+# 3. Section header alignment
+echo "--- Section Headers ---"
+if [ "$dotfiles_agents" -eq 1 ] && [ "$dotfiles_claude" -eq 1 ]; then
+  check_sections "dotfiles" "$DOTFILES_DIR/AGENTS.md" "$DOTFILES_DIR/CLAUDE.md"
+fi
+if [ "$told_agents" -eq 1 ] && [ "$told_claude" -eq 1 ]; then
+  check_sections "told" "$TOLD_DIR/AGENTS.md" "$TOLD_DIR/CLAUDE.md"
+fi
+echo ""
+
+# 4. Stack version alignment
+echo "--- Stack Versions ---"
+if [ "$dotfiles_agents" -eq 1 ] && [ "$dotfiles_claude" -eq 1 ]; then
+  check_stack_versions "dotfiles" "$DOTFILES_DIR/AGENTS.md" "$DOTFILES_DIR/CLAUDE.md"
+fi
+if [ "$told_agents" -eq 1 ] && [ "$told_claude" -eq 1 ]; then
+  check_stack_versions "told" "$TOLD_DIR/AGENTS.md" "$TOLD_DIR/CLAUDE.md"
+fi
+echo ""
+
+# Summary
+echo "=== Summary ==="
+if [ "$ERRORS" -eq 0 ]; then
+  green "All checks passed."
+else
+  red "$ERRORS issue(s) found. See drift-governance.md for recovery steps."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `config/quality/docs/drift-governance.md` — trigger checklist, ownership, cadence for keeping AGENTS.md in sync with CLAUDE.md across repos
- Add `config/quality/scripts/check-agents-drift.sh` — structural drift detection (file presence, size limits, section headers, stack version subset checks)
- Update `config/quality/docs/codex-runbook.md` to reference told's AGENTS.md and drift governance
- Add Codex cross-reference sections to both AGENTS.md and CLAUDE.md
- Refresh dotfiles AGENTS.md with drift governance key file entry

**Told repo changes** (separate commit): `~/src/told/AGENTS.md` created + CLAUDE.md cross-reference added.

## Test plan

- [x] `check-agents-drift.sh` passes (all checks green, WARNs expected for AGENTS-only sections)
- [x] Both AGENTS.md files under 32 KiB Codex limit
- [ ] `nix flake check` — pre-existing nixfmt failure in claude.nix (not from this PR)
- [ ] Verify Codex discovery picks up AGENTS.md in both repos

Fixes TOLD-1773