### PR TITLE
feat(claude): add native Codex account to cc launcher

### DIFF
--- a/modules/home/apps/claude.nix
+++ b/modules/home/apps/claude.nix
@@ -83,6 +83,16 @@ let
       authMethod = "api-key";
       model = "gpt-5.3-codex";
     }
+    {
+      name = "codex";
+      configDir = null;
+      provider = "codex";
+      description = "Codex CLI — native OpenAI agent";
+      secretId = "told/vendor/openai/api-key";
+      email = null;
+      authMethod = "api-key";
+      model = "codex";
+    }
   ];
 
   # Accounts that need their own config directory (configDir != null)
@@ -456,6 +466,15 @@ let
             "  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \\"
             "  AI_ACCOUNT=\"${acct.name}\" \\"
             "  claude \"$@\" ;;"
+          ]
+        else if acct.provider == "codex" then
+          [
+            "${acct.name})"
+            "  key=$(aws secretsmanager get-secret-value --secret-id \"${acct.secretId}\" --region us-east-1 --query SecretString --output text 2>/dev/null)"
+            "  [[ -z \"$key\" ]] && { echo \"ERROR: Secret ${acct.secretId} missing\" >&2; exit 1; }"
+            "  OPENAI_API_KEY=\"$key\" \\"
+            "  AI_ACCOUNT=\"${acct.name}\" \\"
+            "  codex \"$@\" ;;"
           ]
         else
           [ ];


### PR DESCRIPTION
## Summary

- Add `codex` provider type to `accountDefs` in `claude.nix`
- Add `codex` dispatch arm in `mkCaseBranch` — fetches `OPENAI_API_KEY` from AWS Secrets Manager, executes `codex` binary directly
- Existing `mkStatusEntry` generic branch handles status check automatically (no change needed)

## Pre-requisite

AWS secret `told/vendor/openai/api-key` must exist in Secrets Manager (us-east-1) before launch works.

## Test plan

- [ ] `nix flake check` passes (verified)
- [ ] `just switch` rebuilds and regenerates justfile
- [ ] `just -g cc help` shows codex account
- [ ] `just -g cc status` shows codex section
- [ ] `just -g cc codex --version` outputs codex-cli version
- [ ] Existing accounts unaffected: `just -g cc max-1 --version`

Fixes TOLD-1763