### PR TITLE
chore(skills): rename told-vault-worktrees to told-worktrees [TOLD-1851]

### DIFF
--- a/config/claude-code/skills/commit/SKILL.md
+++ b/config/claude-code/skills/commit/SKILL.md
@@ -130,7 +130,7 @@ main_repo="$HOME/src/told-vault"
    ```
 7. Remove parent worktree directory if empty:
    ```bash
-   rmdir "$HOME/told-vault-worktrees" 2>/dev/null || true
+   rmdir "$HOME/told-worktrees" 2>/dev/null || true
    ```
 
 ### If on main repo (not a worktree):

--- a/config/claude-code/skills/commit/SKILL.md
+++ b/config/claude-code/skills/commit/SKILL.md
@@ -128,9 +128,9 @@ main_repo="$HOME/src/told-vault"
    ```bash
    git worktree prune
    ```
-7. Remove parent worktree directory if empty:
+7. Remove parent worktree directory if empty (derive from the worktree path — `~/{repo}-worktrees`):
    ```bash
-   rmdir "$HOME/told-worktrees" 2>/dev/null || true
+   rmdir "$(dirname "<worktree_dir>")" 2>/dev/null || true
    ```
 
 ### If on main repo (not a worktree):

--- a/config/claude-code/skills/plan-ticket/SKILL.md
+++ b/config/claude-code/skills/plan-ticket/SKILL.md
@@ -34,8 +34,12 @@ Create an isolated worktree so parallel `/plan-ticket` sessions don't collide on
 
 ```bash
 BRANCH="hank/{primary_ticket_ref}"
-WORKTREE="$HOME/told-worktrees/{primary_ticket_ref}"
-mkdir -p "$HOME/told-worktrees"
+# Derive worktree root from repo name so each project namespaces its own worktrees
+# (told → ~/told-worktrees, told-vault → ~/told-vault-worktrees, dotfiles → ~/dotfiles-worktrees)
+REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+WORKTREE_ROOT="$HOME/${REPO_NAME}-worktrees"
+WORKTREE="$WORKTREE_ROOT/{primary_ticket_ref}"
+mkdir -p "$WORKTREE_ROOT"
 
 # Clean stale worktree from previous failed run
 if [ -d "$WORKTREE" ]; then
@@ -53,7 +57,7 @@ echo "Worktree: $WORKTREE"
 echo "Branch: $BRANCH"
 ```
 
-Store `WORKTREE_PATH = $HOME/told-worktrees/{primary_ticket_ref}` for Phase 3.
+Store `WORKTREE_PATH = $WORKTREE_ROOT/{primary_ticket_ref}` (e.g. `$HOME/told-worktrees/told-1851`) for Phase 3.
 
 **CRITICAL**: Phase 3 implementation MUST use `WORKTREE_PATH` for ALL file paths. For example, use `$WORKTREE_PATH/decisions/PITCH.md` — NOT the main repo path. The main repo stays untouched.
 
@@ -204,7 +208,7 @@ The plan is locked. Begin implementation immediately **in the worktree**:
 
 1. Read the locked plan file: `~/.claude/plans/{primary_ticket_ref}.md`
 2. Parse the `## File Change Map` table — this is your implementation checklist
-3. Implement each file change in the order specified by the plan, using **`WORKTREE_PATH`** (`$HOME/told-worktrees/{primary_ticket_ref}`) for ALL file paths (Read, Edit, Glob, Grep)
+3. Implement each file change in the order specified by the plan, using **`WORKTREE_PATH`** (`$WORKTREE_ROOT/{primary_ticket_ref}`, e.g. `$HOME/told-worktrees/told-1851`) for ALL file paths (Read, Edit, Glob, Grep)
 4. Follow all architecture decisions and patterns specified in the plan
 
 ### Ship it

--- a/config/claude-code/skills/plan-ticket/SKILL.md
+++ b/config/claude-code/skills/plan-ticket/SKILL.md
@@ -34,8 +34,8 @@ Create an isolated worktree so parallel `/plan-ticket` sessions don't collide on
 
 ```bash
 BRANCH="hank/{primary_ticket_ref}"
-WORKTREE="$HOME/told-vault-worktrees/{primary_ticket_ref}"
-mkdir -p "$HOME/told-vault-worktrees"
+WORKTREE="$HOME/told-worktrees/{primary_ticket_ref}"
+mkdir -p "$HOME/told-worktrees"
 
 # Clean stale worktree from previous failed run
 if [ -d "$WORKTREE" ]; then
@@ -53,7 +53,7 @@ echo "Worktree: $WORKTREE"
 echo "Branch: $BRANCH"
 ```
 
-Store `WORKTREE_PATH = $HOME/told-vault-worktrees/{primary_ticket_ref}` for Phase 3.
+Store `WORKTREE_PATH = $HOME/told-worktrees/{primary_ticket_ref}` for Phase 3.
 
 **CRITICAL**: Phase 3 implementation MUST use `WORKTREE_PATH` for ALL file paths. For example, use `$WORKTREE_PATH/decisions/PITCH.md` — NOT the main repo path. The main repo stays untouched.
 
@@ -204,7 +204,7 @@ The plan is locked. Begin implementation immediately **in the worktree**:
 
 1. Read the locked plan file: `~/.claude/plans/{primary_ticket_ref}.md`
 2. Parse the `## File Change Map` table — this is your implementation checklist
-3. Implement each file change in the order specified by the plan, using **`WORKTREE_PATH`** (`$HOME/told-vault-worktrees/{primary_ticket_ref}`) for ALL file paths (Read, Edit, Glob, Grep)
+3. Implement each file change in the order specified by the plan, using **`WORKTREE_PATH`** (`$HOME/told-worktrees/{primary_ticket_ref}`) for ALL file paths (Read, Edit, Glob, Grep)
 4. Follow all architecture decisions and patterns specified in the plan
 
 ### Ship it


### PR DESCRIPTION
## Summary

The `plan-ticket` and `commit` skills live in `dotfiles` and serve every repo. Hardcoding any specific project name in them is wrong. Derive worktree root from the repo name instead:

```bash
REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
WORKTREE_ROOT="$HOME/${REPO_NAME}-worktrees"
```

Each repo namespaces its own worktrees:

| Repo | Worktree root |
|------|---------------|
| `told` | `~/told-worktrees/` |
| `told-vault` | `~/told-vault-worktrees/` |
| `dotfiles` | `~/dotfiles-worktrees/` |

Commit skill cleanup now `rmdir`s `$(dirname <worktree_dir>)` instead of a hardcoded path.

## Commits

1. First commit renamed `told-vault-worktrees` → `told-worktrees` (still wrong — project name hardcoded in a generic skill).
2. Second commit replaces the hardcode with auto-derive.

Will be squash-merged, so the first commit won't land on `main`.

## Files

- `config/claude-code/skills/plan-ticket/SKILL.md`
- `config/claude-code/skills/commit/SKILL.md`

## Test plan

- [x] `grep "told-worktrees" config/claude-code/skills/` returns only example comments, no hardcoded path assignments
- [ ] Next `/plan-ticket` invocation in `~/src/told` creates worktree under `~/told-worktrees/`
- [ ] `/commit` cleanup `rmdir`s the right parent directory

Fixes TOLD-1851
