### PR TITLE
fix(codex): rename [features].codex_hooks to hooks, bump model to gpt-5.5 [CC-85]

### DIFF
--- a/config/quality/src/generators/codex/config-toml.generator.test.ts
+++ b/config/quality/src/generators/codex/config-toml.generator.test.ts
@@ -50,6 +50,21 @@ describe('codex config-toml generator', () => {
     expect(config.approval_policy).toBeTypeOf('string')
   })
 
+  it('pins model to gpt-5.5', async () => {
+    const filePath = await generateToTmp()
+    // biome-ignore lint/suspicious/noExplicitAny: parsed TOML shape
+    const config: any = TOML.parse(readFileSync(filePath, 'utf8'))
+    expect(config.model).toBe('gpt-5.5')
+  })
+
+  it('emits [features].hooks (not deprecated codex_hooks)', async () => {
+    const filePath = await generateToTmp()
+    // biome-ignore lint/suspicious/noExplicitAny: parsed TOML shape
+    const config: any = TOML.parse(readFileSync(filePath, 'utf8'))
+    expect(config.features?.hooks).toBe(true)
+    expect(config.features?.codex_hooks).toBeUndefined()
+  })
+
   it('declares the ref MCP server', async () => {
     const filePath = await generateToTmp()
     // biome-ignore lint/suspicious/noExplicitAny: parsed TOML shape

--- a/config/quality/src/generators/codex/config-toml.generator.ts
+++ b/config/quality/src/generators/codex/config-toml.generator.ts
@@ -11,7 +11,7 @@
  *
  * Sections emitted:
  *   - top-level `model`, `model_provider`, `approval_policy`, `sandbox_mode`
- *   - `[features]`             enable codex_hooks, multi_agent, web_search
+ *   - `[features]`             enable hooks, multi_agent, plugins
  *   - `[shell_environment_policy]`
  *   - `[mcp_servers.<name>]`   one block per MCP server (ref only today)
  *   - `[[hooks.<Event>]]`      from CODEX_HOOK_DEFINITIONS
@@ -34,7 +34,7 @@ import {
 // Defaults
 // =============================================================================
 
-const CODEX_MODEL = 'gpt-5.3-codex'
+const CODEX_MODEL = 'gpt-5.5'
 const CODEX_MODEL_PROVIDER = 'openai'
 const CODEX_SANDBOX_MODE = 'workspace-write'
 const CODEX_APPROVAL_POLICY = 'on-request'
@@ -50,7 +50,10 @@ const tomlString = (s: string): string => {
   return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
 }
 
-const emitHookBlocks = (event: CodexHookEvent, groups: readonly CodexMatcherHookGroup[]): string => {
+const emitHookBlocks = (
+  event: CodexHookEvent,
+  groups: readonly CodexMatcherHookGroup[],
+): string => {
   if (groups.length === 0) return ''
   const lines: string[] = []
   for (const group of groups) {
@@ -97,7 +100,7 @@ const generateConfigToml = (): string => {
 
   // --- Features
   lines.push('[features]')
-  lines.push('codex_hooks = true')
+  lines.push('hooks = true')
   lines.push('multi_agent = true')
   lines.push('plugins = true')
   lines.push('')

--- a/config/quality/src/hooks/lib/guards/procedural.ts
+++ b/config/quality/src/hooks/lib/guards/procedural.ts
@@ -136,10 +136,13 @@ export function checkNixCleanGitState(command: string): GuardResult {
     const dotfilesPath = process.env['HOME'] + '/dotfiles'
 
     // Check for uncommitted changes in modules/ and config/ directories
-    const status = execSync('git status --porcelain modules/ config/ flake.nix flake.lock 2>/dev/null || true', {
-      cwd: dotfilesPath,
-      encoding: 'utf8',
-    }).trim()
+    const status = execSync(
+      'git status --porcelain modules/ config/ flake.nix flake.lock 2>/dev/null || true',
+      {
+        cwd: dotfilesPath,
+        encoding: 'utf8',
+      },
+    ).trim()
 
     if (status.length > 0) {
       const changedFiles = status
@@ -147,7 +150,8 @@ export function checkNixCleanGitState(command: string): GuardResult {
         .map((line: string) => line.substring(3))
         .slice(0, 5)
         .join('\n  ')
-      const hasMore = status.split('\n').length > 5 ? `\n  ... and ${status.split('\n').length - 5} more` : ''
+      const hasMore =
+        status.split('\n').length > 5 ? `\n  ... and ${status.split('\n').length - 5} more` : ''
 
       return {
         ok: false,
@@ -971,7 +975,14 @@ export function checkStringErrorConversion(content: string, filePath: string): G
 
 export function runProceduralGuards(
   toolName: string,
-  toolInput: { file_path?: string; content?: string; command?: string; pattern?: string; glob?: string; path?: string },
+  toolInput: {
+    file_path?: string
+    content?: string
+    command?: string
+    pattern?: string
+    glob?: string
+    path?: string
+  },
 ): GuardResult {
   const { file_path: filePath, content, command, pattern, glob, path } = toolInput
 

--- a/config/quality/src/hooks/pre-tool-use.ts
+++ b/config/quality/src/hooks/pre-tool-use.ts
@@ -87,9 +87,24 @@ const runProceduralChecks = (
   input: PreToolUseInput,
 ): Effect.Effect<GuardCheckResult, never, never> =>
   Effect.sync(() => {
-    const { file_path: filePath, content, new_string, command, pattern, glob, path } = input.tool_input
+    const {
+      file_path: filePath,
+      content,
+      new_string,
+      command,
+      pattern,
+      glob,
+      path,
+    } = input.tool_input
     const effectiveContent = content ?? new_string
-    const toolInput: { file_path?: string; content?: string; command?: string; pattern?: string; glob?: string; path?: string } = {}
+    const toolInput: {
+      file_path?: string
+      content?: string
+      command?: string
+      pattern?: string
+      glob?: string
+      path?: string
+    } = {}
     if (filePath !== undefined) toolInput.file_path = filePath
     if (effectiveContent !== undefined) toolInput.content = effectiveContent
     if (command !== undefined) toolInput.command = command


### PR DESCRIPTION
## Summary
- Rename `[features].codex_hooks` → `[features].hooks` in Codex config generator (Codex v0.130 deprecation).
- Bump `CODEX_MODEL` default from `gpt-5.3-codex` → `gpt-5.5`. Generator now matches the manually-edited deployed `~/.codex-max-N/config.toml` so `just switch` no longer clobbers it.
- Lock both fixes with new vitest assertions; incidental biome format normalization for two unrelated hook files.

## Test plan
- [x] `bun run validate` (74/74 tests pass) inside `config/quality`
- [x] `bun run check` (typecheck + format + lint clean)
- [x] `just check` (flake validates)
- [ ] After merge + `just switch`: `cx codex-max-1` starts without `codex_hooks` deprecation warning; TUI shows `gpt-5.5`

---
Fixes CC-85
