### PR TITLE
fix(codex): suppress approve/skip decisions Codex rejects [CC-86]

### DIFF
--- a/config/quality/src/hooks/lib/effect-hook.ts
+++ b/config/quality/src/hooks/lib/effect-hook.ts
@@ -9,6 +9,7 @@
 
 import { Console, Effect, Schema } from 'effect'
 import { codexToClaudeShape, isCodexShape } from './hook-input-codex'
+import { shouldSuppressDecision } from './hook-output-codex'
 
 // =============================================================================
 // Hook Protocol Types (must match SSOT at config/agents/hooks/lib/types.ts)
@@ -150,6 +151,10 @@ export const parseInput = (raw: string) =>
 
 export const outputDecision = (decision: HookDecision) =>
   Effect.gen(function* () {
+    // Codex rejects `decision: 'approve' | 'skip'` with a red TUI notice
+    // before failing open. Suppress these emissions under Codex; `block` is
+    // honored by both harnesses and always emitted. See lib/hook-output-codex.ts.
+    if (shouldSuppressDecision(decision)) return
     yield* Console.log(JSON.stringify(decision))
   })
 

--- a/config/quality/src/hooks/lib/hook-logging.ts
+++ b/config/quality/src/hooks/lib/hook-logging.ts
@@ -7,6 +7,8 @@
  * Zero dependencies - hooks should be lightweight.
  */
 
+import { shouldSuppressDecision } from './hook-output-codex'
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -43,6 +45,10 @@ export type HookContinue = {
  * ```
  */
 export const emitDecision = (output: HookDecision): void => {
+  // Codex rejects `decision: 'approve' | 'skip'` with a red TUI notice
+  // before failing open. Suppress these emissions under Codex; `block` is
+  // honored by both harnesses and always emitted. See ./hook-output-codex.
+  if (shouldSuppressDecision(output)) return
   process.stdout.write(`${JSON.stringify(output)}\n`)
 }
 

--- a/config/quality/src/hooks/lib/hook-output-codex.test.ts
+++ b/config/quality/src/hooks/lib/hook-output-codex.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Codex hook output adapter tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isCodexOutputContext, shouldSuppressDecision } from './hook-output-codex'
+
+const ENV_KEY = 'CODEX_HOME'
+let prev: string | undefined
+
+beforeEach(() => {
+  prev = process.env[ENV_KEY]
+})
+
+afterEach(() => {
+  if (prev === undefined) {
+    delete process.env[ENV_KEY]
+  } else {
+    process.env[ENV_KEY] = prev
+  }
+})
+
+describe('isCodexOutputContext', () => {
+  it('returns true when CODEX_HOME is a non-empty string', () => {
+    process.env[ENV_KEY] = '/Users/hank/.codex-max-1'
+    expect(isCodexOutputContext()).toBe(true)
+  })
+
+  it('returns false when CODEX_HOME is unset', () => {
+    delete process.env[ENV_KEY]
+    expect(isCodexOutputContext()).toBe(false)
+  })
+
+  it('returns false when CODEX_HOME is an empty string', () => {
+    process.env[ENV_KEY] = ''
+    expect(isCodexOutputContext()).toBe(false)
+  })
+})
+
+describe('shouldSuppressDecision — under Codex', () => {
+  beforeEach(() => {
+    process.env[ENV_KEY] = '/Users/hank/.codex-max-1'
+  })
+
+  it('suppresses approve', () => {
+    expect(shouldSuppressDecision({ decision: 'approve' })).toBe(true)
+  })
+
+  it('suppresses approve with reason', () => {
+    expect(shouldSuppressDecision({ decision: 'approve', reason: 'guard passed' })).toBe(true)
+  })
+
+  it('suppresses skip', () => {
+    expect(shouldSuppressDecision({ decision: 'skip' })).toBe(true)
+  })
+
+  it('emits block (never suppressed)', () => {
+    expect(shouldSuppressDecision({ decision: 'block', reason: 'forbidden file' })).toBe(false)
+  })
+})
+
+describe('shouldSuppressDecision — under Claude Code', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  it('emits approve (no suppression without CODEX_HOME)', () => {
+    expect(shouldSuppressDecision({ decision: 'approve' })).toBe(false)
+  })
+
+  it('emits skip (no suppression without CODEX_HOME)', () => {
+    expect(shouldSuppressDecision({ decision: 'skip' })).toBe(false)
+  })
+
+  it('emits block (no suppression without CODEX_HOME)', () => {
+    expect(shouldSuppressDecision({ decision: 'block', reason: 'x' })).toBe(false)
+  })
+})

--- a/config/quality/src/hooks/lib/hook-output-codex.ts
+++ b/config/quality/src/hooks/lib/hook-output-codex.ts
@@ -1,0 +1,56 @@
+/**
+ * Codex CLI hook output adapter.
+ *
+ * Claude Code accepts `{ decision: 'approve' | 'block' | 'skip', reason? }`
+ * on stdout from hook scripts. Codex (v0.130+) parses the same JSON envelope
+ * but only honors `decision: 'block'` — any other `decision` value is rejected
+ * with a red "unsupported decision:<value>" notice in the TUI before "failing
+ * open" (allowing the tool call). The notice is harmless but noisy: every
+ * approve/skip emission from a passing guard surfaces as an error to the user.
+ *
+ * The symmetric counterpart to `hook-input-codex.ts`: that module projects
+ * Codex stdin INTO the Claude shape; this module suppresses outbound emissions
+ * that the Claude shape allows but Codex would reject.
+ *
+ * References:
+ *   - https://developers.openai.com/codex/hooks (output schema)
+ *   - Codex `codex-rs/exec/src/hook_runner.rs` (decision parser)
+ *   - Linear CC-86
+ *
+ * Detection:
+ *   `CODEX_HOME` is set by the `cx` recipe before launching Codex, so its
+ *   presence is the canonical "we are running under Codex" signal. We do NOT
+ *   peek at the input shape here because the hook may have already consumed
+ *   stdin by the time output emission happens.
+ */
+
+export type SuppressibleDecision = {
+  readonly decision: string
+  readonly [key: string]: unknown
+}
+
+/**
+ * True when the current process was launched under Codex.
+ *
+ * The `cx` recipe (modules/home/apps/codex.nix) exports `CODEX_HOME` before
+ * exec'ing the Codex binary. Hook scripts inherit it via Codex's child-process
+ * environment.
+ */
+export const isCodexOutputContext = (): boolean =>
+  typeof process.env['CODEX_HOME'] === 'string' && process.env['CODEX_HOME'].length > 0
+
+/**
+ * True when the given hook decision should NOT be emitted to stdout under
+ * Codex. Currently: `approve` and `skip` — both produce a red "unsupported
+ * decision" notice in the Codex TUI even though they fail-open semantically.
+ *
+ * `block` is always emitted: Codex honors it and surfaces the `reason` to
+ * the user as intended.
+ *
+ * Under Claude Code (no `CODEX_HOME`), this always returns false so the
+ * existing emission behavior is preserved.
+ */
+export const shouldSuppressDecision = (decision: SuppressibleDecision): boolean => {
+  if (!isCodexOutputContext()) return false
+  return decision.decision === 'approve' || decision.decision === 'skip'
+}


### PR DESCRIPTION
## Summary
- Codex's hook runner parses Claude Code's stdout JSON but only honors `decision: 'block'` — `approve`/`skip` produce a red "unsupported decision:<value>" notice in the TUI before failing open, so every passing PreToolUse guard surfaced as an error to the user.
- Adds `config/quality/src/hooks/lib/hook-output-codex.ts` symmetric to `hook-input-codex.ts` (CODEX_HOME-based detection + `shouldSuppressDecision`).
- Gates both terminal emitters — `outputDecision` in `effect-hook.ts` (Effect path used by `pre-tool-use.ts`) and `emitDecision` in `hook-logging.ts` (zero-dep path) — to short-circuit `approve`/`skip` under Codex. `block` always emits; Claude Code behavior unchanged.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test src/hooks/` — 52/52 pass (10 new + 42 prior)
- [x] `just check` — all flake checks green, 0 audit findings
- [ ] Codex smoke: `cx` session running `Bash(git status)`, `Bash(rm -rf /)` (should still block with reason), and `apply_patch` show no red "unsupported decision" notice
- [ ] Claude Code smoke: `cc` session — `approve(reason)` warnings still surface in transcript (no regression)

---
Fixes CC-86
