### PR TITLE
fix(codex): symlink subagents into $CODEX_HOME/agents/ [CC-87]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Per [Codex skills docs](https://developers.openai.com/codex/skills) and Phase B 
 |---------|-----------------|----------------------|
 | Skills | `config/claude-code/skills/*/SKILL.md` | `~/.agents/skills/` (per-user) + `<repo>/.agents/skills/` (project) |
 | Hooks | `config/quality/src/hooks/*.ts` (Effect-TS, bun) | invoked via `[[hooks.<Event>]]` in `~/.codex-<acct>/config.toml` |
-| Sub-agents | `config/claude-code/agents/*.md` | `~/.agents/agents/<name>.toml` (user-scope shared dir, standalone TOML files, not `[profiles.<name>]`) |
+| Sub-agents | `config/claude-code/agents/*.md` | `$CODEX_HOME/agents/<name>.toml` (per-account user scope) + `$CWD/.codex/agents/<name>.toml` (project scope). Standalone TOML files, not `[profiles.<name>]`. |
 | Slash commands | `config/claude/commands/*.md` | Codex built-ins only; user extensions go through skills |
 | MCP servers | `modules/home/apps/claude.nix` (cliAllJson) | `[mcp_servers.<name>]` in `~/.codex-<acct>/config.toml` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ After Phase B, this repo also drives a Codex CLI harness in parallel. Both harne
 | Skills discovery | `~/.claude/skills` (symlinked per CLAUDE_CONFIG_DIR) | `~/.agents/skills` (per-user, shared) |
 | Hook event count | ~30 | 8 (PreToolUse, PostToolUse, PermissionRequest, SessionStart, UserPromptSubmit, Stop, PreCompact, PostCompact) |
 | Hook script entry | `config/quality/src/hooks/*.ts` (Effect-TS, bun) | same scripts — `lib/hook-input-codex.ts` adapter projects Codex stdin to Claude shape inside `parseInput` |
-| Subagents | Markdown agents in `config/claude-code/agents/*.md` | Standalone TOML at `~/.agents/agents/<name>.toml` (architect ported in Phase B) |
+| Subagents | Markdown agents in `config/claude-code/agents/*.md` | Standalone TOML at `$CODEX_HOME/agents/<name>.toml` (per-account user scope) + `$CWD/.codex/agents/<name>.toml` (project scope); architect ported in Phase B |
 | Sandbox model | Permissions allow/deny in settings.json | `sandbox_mode` + `approval_policy` in config.toml; per-project overrides in `.codex/config.toml` |
 
 ## Key Files

--- a/config/claude-code/skills/commit/SKILL.md
+++ b/config/claude-code/skills/commit/SKILL.md
@@ -2,7 +2,6 @@
 name: commit
 allowed-tools: Bash(git *), Bash(gh *), Bash(eval *), Bash(export *), Bash(jq *), Bash(curl *), Bash(while *), Bash(sleep *), Bash(date *), Bash(ls *), Bash(rm *), Read, Edit, Glob, Grep, Task
 description: Commit, push, create PR, monitor checks, auto-merge, and clean up worktree
-disable-model-invocation: true
 ---
 
 # Commit -> PR -> Merge -> Clean Up

--- a/config/quality/docs/adr/015-codex-harness-port.md
+++ b/config/quality/docs/adr/015-codex-harness-port.md
@@ -46,7 +46,7 @@ The original "Codex is a fallback, no quality enforcement, no shared skills" sta
 - Hooks live at `config/quality/src/hooks/*.ts`. A new `lib/hook-input-codex.ts` adapter projects Codex's stdin JSON into the Claude shape the existing scripts consume. The hook scripts call the adapter conditionally based on `CODEX_HOME` env presence (T10).
 - A new generator at `config/quality/src/generators/codex/` emits `generated/codex/config.toml` from a `codex-definitions.ts` SSOT (parallel to `definitions.ts` for Claude).
 - `modules/home/apps/codex.nix` mirrors `claude.nix`'s symlink farm to wire `~/.codex-max-N/{AGENTS.md, config.toml, agents/}` per account.
-- Architect agent ports to `~/.codex/agents/architect.toml` (a standalone TOML agent file, not `[profiles.architect]` — profiles are flagged experimental in v0.130).
+- Architect agent ports to `$CODEX_HOME/agents/architect.toml` (per-account; e.g. `~/.codex-max-1/agents/architect.toml`). Standalone TOML agent file, not `[profiles.architect]` — profiles are flagged experimental in v0.130. See "Correction (CC-87)" at the end of this ADR.
 - The Caveman plugin is intentionally NOT ported as a Codex plugin. The persona is encoded in `AGENTS.md` prose / a `personality` preset; the marketplace plugin path is gated on `plugin_hooks` stabilizing (currently under-development).
 
 ### Hook event mapping
@@ -122,5 +122,11 @@ Hook events Claude has that Codex does not: `Notification`, `SubagentStart/Stop`
 - CC-60 Phase B doc (locked source of truth for the port).
 - ADR-014 (superseded by this ADR).
 - ADR-007 (hook architecture; underlying pattern reused).
-- Codex docs: [hooks](https://developers.openai.com/codex/hooks), [skills](https://developers.openai.com/codex/skills), [config-reference](https://developers.openai.com/codex/config-reference).
+- Codex docs: [hooks](https://developers.openai.com/codex/hooks), [skills](https://developers.openai.com/codex/skills), [subagents](https://developers.openai.com/codex/subagents), [config-reference](https://developers.openai.com/codex/config-reference).
 - PR [#18391](https://github.com/openai/codex/pull/18391) — apply_patch hook fix.
+
+## Correction (CC-87, 2026-05-11)
+
+Phase B's initial implementation symlinked the architect to `~/.agents/agents/architect.toml`, conflating the skills user-scope (`~/.agents/skills/`) with the subagents user-scope. Per [Codex subagents docs](https://developers.openai.com/codex/subagents#custom-agents), subagents are discovered at `$CODEX_HOME/agents/` (user) and `$CWD/.codex/agents/` (project) — there is no `~/.agents/agents/` scan path. Skills and subagents share no directory.
+
+CC-87 moves the architect symlink farm into `$CODEX_HOME/agents/<name>.toml` per account (e.g. `~/.codex-max-1/agents/architect.toml`) and enumerates `config/claude-code/agents/*.toml` so new agents auto-deploy on `just switch`. The `~/.agents/skills` user-scope symlink is unchanged (skills *do* live there per the skills docs). Sibling told-repo work renames `~/src/told/.agents/agents/` → `~/src/told/.codex/agents/` to expose the 16 reviewer + 1 synthesizer subagents at project scope.

--- a/config/quality/docs/drift-governance.md
+++ b/config/quality/docs/drift-governance.md
@@ -70,7 +70,7 @@ but a few areas diverge by design. Don't treat these as drift to fix.
 | Hook stdin shape | `tool_name`, `tool_input.{file_path,content,...}`, `session_id` | `tool_name`, `tool_input.command` (raw patch body), `tool_use_id`, `turn_id` | `config/quality/src/hooks/lib/hook-input-codex.ts` adapter projects Codex → Claude shape |
 | Per-skill `allowed-tools` | First-class in SKILL.md frontmatter | Not supported | Permission lives in `approval_policy` + `sandbox_mode` per project `.codex/config.toml` |
 | Custom slash commands | `config/claude/commands/*.md` | Not user-extensible — all user surfaces are skills | The `commit` / `add-app` / `clean-claude` commands stay Claude-only; Codex users invoke equivalents via skills |
-| Subagent definition | Markdown with frontmatter (`agents/*.md`) | Standalone TOML (`~/.agents/agents/*.toml`) | `config/claude-code/agents/architect.toml` mirrors the `.md` body |
+| Subagent definition | Markdown with frontmatter (`agents/*.md`) | Standalone TOML — user: `$CODEX_HOME/agents/*.toml`; project: `$CWD/.codex/agents/*.toml` | `config/claude-code/agents/architect.toml` symlinked into each `$CODEX_HOME/agents/` (CC-87 corrected from `~/.agents/agents/`) |
 | Plugin manifest path | `.claude-plugin/plugin.json` | `.codex-plugin/plugin.json` (per CC-60 doc) or `.claude-plugin/plugin.json` (per audit reconciliation — cross-tool) | T13 (stretch) verifies before publishing |
 | `apply_patch` hook coverage | N/A — separate tools | Fires `PreToolUse`/`PostToolUse` since v0.130 (PR #18391) | Single matcher in codex-definitions.ts |
 | `requirements.toml` (org pin) | N/A | Codex admin-enforced constraint file | Not used in personal dotfiles; would live at `~/.codex/requirements.toml` |

--- a/config/quality/src/generators/codex/config-toml.generator.ts
+++ b/config/quality/src/generators/codex/config-toml.generator.ts
@@ -147,9 +147,12 @@ const generateConfigToml = (): string => {
   lines.push('job_max_runtime_seconds = 1800')
   lines.push('')
 
-  // --- Built-in agent definitions are loaded from ~/.agents/agents/*.toml
-  //     (symlinked by codex.nix). Listed here as a stable reference.
-  lines.push('# Subagents discovered from ~/.agents/agents/*.toml:')
+  // --- Subagent TOML files are discovered by Codex at runtime from
+  //     $CODEX_HOME/agents/*.toml (user scope) and $CWD/.codex/agents/*.toml
+  //     (project scope). codex.nix symlinks every config/claude-code/agents/*.toml
+  //     into each $CODEX_HOME/agents/. Listed here as a stable reference.
+  lines.push('# Subagents discovered from $CODEX_HOME/agents/*.toml (user)')
+  lines.push('# and $CWD/.codex/agents/*.toml (project):')
   lines.push('#   - architect (config/claude-code/agents/architect.toml)')
   lines.push('')
 

--- a/modules/home/apps/codex.nix
+++ b/modules/home/apps/codex.nix
@@ -57,20 +57,46 @@ let
   );
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # USER-SCOPED .agents/ SYMLINK FARM
-  # Codex resolves skills and subagents from ~/.agents/{skills,agents}/ at
-  # user scope (per agentskills.io standard + Codex docs). Shared across all
-  # accounts; dotfiles owns the source of truth.
+  # USER-SCOPED .agents/skills SYMLINK
+  # Codex resolves skills from ~/.agents/skills/ at user scope (agentskills.io
+  # standard, Codex skills docs). Shared across all accounts; dotfiles owns
+  # the source of truth.
+  #
+  # Subagents do NOT live here. Per Codex docs, subagents are discovered at
+  # $CODEX_HOME/agents/ (user scope) and $CWD/.codex/agents/ (project scope).
+  # See perAccountAgentSymlinks below for the per-account user-scope farm.
   # ═══════════════════════════════════════════════════════════════════════════
 
   userAgentsSymlinks = {
     ".agents/skills" = {
       source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude-code/skills";
     };
-    ".agents/agents/architect.toml" = {
-      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude-code/agents/architect.toml";
-    };
   };
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # PER-ACCOUNT SUBAGENT FARM
+  # Codex's user-scope subagent path is $CODEX_HOME/agents/*.toml. Enumerate
+  # config/claude-code/agents/*.toml and symlink each one into every account's
+  # agents dir. Dropping a new TOML file auto-deploys on next `just switch`.
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  agentTomlNames = builtins.attrNames (
+    lib.filterAttrs (n: t: t == "regular" && lib.hasSuffix ".toml" n) (
+      builtins.readDir ../../../config/claude-code/agents
+    )
+  );
+
+  perAccountAgentSymlinks = builtins.listToAttrs (
+    lib.concatMap (
+      acct:
+      map (fname: {
+        name = "${acct.codexHome}/agents/${fname}";
+        value = {
+          source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/config/claude-code/agents/${fname}";
+        };
+      }) agentTomlNames
+    ) codexAccountDefs
+  );
 
   # ═══════════════════════════════════════════════════════════════════════════
   # `cx` RECIPE GENERATION (mirrors claude.nix:411–576)
@@ -204,8 +230,9 @@ in
 
   config = mkIf config.modules.home.apps.codex.enable {
     # Per-account AGENTS.md symlinks (~/.codex-max-N/AGENTS.md → ~/dotfiles/AGENTS.md)
-    # + user-scoped .agents/{skills,agents} farm (Codex's canonical discovery path).
-    home.file = perAccountSymlinks // userAgentsSymlinks;
+    # + user-scope skills symlink (~/.agents/skills) + per-account subagent
+    # symlinks (~/.codex-max-N/agents/<name>.toml).
+    home.file = perAccountSymlinks // userAgentsSymlinks // perAccountAgentSymlinks;
 
     # Activation hook: deploy the generated config.toml to each CODEX_HOME.
     # MUST run AFTER `generateQuality` (defined in claude.nix) — otherwise


### PR DESCRIPTION
## Summary

- Replace bogus `~/.agents/agents/architect.toml` symlink with a per-account farm that emits `${codexHome}/agents/<name>.toml` for every account × every `config/claude-code/agents/*.toml`. Codex's user-scope subagent path is `$CODEX_HOME/agents/`, not `~/.agents/agents/` — the previous wiring conflated the skills user-scope with the subagents user-scope, leaving Codex blind to anything beyond the single literal `architect.toml` symlink.
- Enumerate via `builtins.readDir` so dropping a new agent TOML auto-deploys on the next `just switch`.
- Drop `disable-model-invocation: true` from `commit` skill so `/commit` is callable from the Skill tool (enables `plan-ticket` → `commit` chaining).
- Sync the generator comment + ADR-015 (line 49 + new "Correction (CC-87)" section) + AGENTS.md subagent row + CLAUDE.md dual-harness row + drift-governance subagent row.

## Test plan

- [x] `bun run generate` regenerates `config/quality/generated/codex/config.toml` with the corrected `# Subagents discovered from $CODEX_HOME/agents/*.toml (user) ...` comment.
- [x] `just check` passes (flake eval, treefmt, pre-commit, security audit all green).
- [x] `nix eval` confirms `home.file.".codex-max-1/agents/architect.toml"` is wired through `mkOutOfStoreSymlink`.
- [ ] After merge + `just switch`: `ls -la ~/.codex-max-1/agents/` shows `architect.toml` symlink; `~/.agents/agents/` no longer present.
- [ ] After merge + `just switch`: `cx codex-max-1` shows `architect` in `/agents`; spawning it loads the read-only sandbox + planning brief from `config/claude-code/agents/architect.toml`.
- [ ] Sibling told-repo ticket (rename `~/src/told/.agents/agents/` → `~/src/told/.codex/agents/`) lands and 18 subagents become visible from a told worktree.

## Plan

`~/.claude/plans/cc-87.md`

Fixes CC-87